### PR TITLE
feat(indexer): Swift言語サポートの追加（tree-sitter AST解析）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,10 @@ Examples:
 
 1. **Binary Detection**: Files are sampled (first 32KB) for null bytes or UTF-8 replacement chars to determine binary status. Binary files are indexed but content is not stored.
 
-2. **Language Detection**: Based on file extension mapping in `src/indexer/language.ts`. Extensible for new languages.
+2. **Language Detection**: Based on file extension mapping in `src/indexer/language.ts`. Currently supports symbol extraction for:
+   - **TypeScript** (`.ts`, `.tsx`): Uses TypeScript Compiler API
+   - **Swift** (`.swift`): Uses tree-sitter-swift
+   - Other languages are detected but symbols are not extracted (fallback to full-file snippets)
 
 3. **Repo ID Resolution**: Each indexed repository gets an auto-incrementing ID. The server resolves `repoRoot` → `repoId` at startup and stores it in `ServerContext`.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@
 - **🔌 MCP Integration**: JSON-RPC 2.0 over stdio/HTTP
 - **👁️ Watch Mode**: Automatic re-indexing on file changes with debouncing
 
+## 📝 Supported Languages
+
+KIRI currently supports AST-based symbol extraction for:
+
+| Language       | Extensions    | Symbol Types                                                                   | Parser                  |
+| -------------- | ------------- | ------------------------------------------------------------------------------ | ----------------------- |
+| **TypeScript** | `.ts`, `.tsx` | `class`, `interface`, `enum`, `function`, `method`                             | TypeScript Compiler API |
+| **Swift**      | `.swift`      | `class`, `struct`, `protocol`, `enum`, `extension`, `func`, `init`, `property` | tree-sitter-swift       |
+
+Other languages are detected and indexed but use full-file snippets instead of symbol-level extraction. Support for additional languages (Rust, Go, Python, etc.) is planned.
+
 ## 🚀 Quick Start
 
 ### Installation

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -5,8 +5,10 @@
 1. **ワークツリー列挙**: `git ls-files` を用いつつ ignore を尊重し、サブモジュールは別リポジトリとして扱う。
 2. **メタデータ推定**: 拡張子から言語判定し、サイズ・mtime・バイナリ判定（ヌルバイト/閾値）を取得する。
 3. **blob/tree 生成**: blob をハッシュで重複排除し、HEAD 時点の path→blob 対応を保持する。
-4. **シンボル抽出**: tree-sitter（推奨）または ctags で定義・範囲・シグネチャを抽出する。
-5. **依存解決**: TypeScript プラグイン（`tsconfig` の paths/alias、`package.json` exports、`pnpm-workspace`）を基準にし、他言語プラグインは後続拡張とする。
+4. **シンボル抽出**: TypeScript (TypeScript Compiler API) と Swift (tree-sitter) で定義・範囲・シグネチャを抽出する。
+   - **TypeScript**: `class`, `interface`, `enum`, `function`, `method`
+   - **Swift**: `class`, `struct`, `protocol`, `enum`, `extension`, `func`, `init`, `property`
+5. **依存解決**: TypeScript プラグイン（`tsconfig` の paths/alias、`package.json` exports、`pnpm-workspace`）と Swift (`import` 文解析）を基準にし、他言語プラグインは後続拡張とする。
 6. **snippet 切り出し**: 原則シンボル境界を用い、特定できない場合のみ 120–200 行のスライディングウィンドウを適用する。
 7. **埋め込み生成（任意）**: snippet 単位で埋め込みを計算し `snippet_embedding` テーブルへ格納する。
 8. **履歴・blame 更新**: 差分ファイルのみ更新し、フル再計算は週次などバッチで実施する。

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "duckdb": "^1.1.0",
     "gpt-tokenizer": "^3.2.0",
     "tree-sitter": "^0.22.0",
+    "tree-sitter-swift": "0.7.1",
     "typescript": "^5.6.3",
     "yaml": "^2.8.1",
     "zod": "^4.1.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       tree-sitter:
         specifier: ^0.22.0
         version: 0.22.4
+      tree-sitter-swift:
+        specifier: 0.7.1
+        version: 0.7.1(tree-sitter@0.22.4)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -2024,6 +2027,20 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-sitter-cli@0.23.2:
+    resolution: {integrity: sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  tree-sitter-swift@0.7.1:
+    resolution: {integrity: sha512-pneKVTuGamaBsqqqfB9BvNQjktzh/0IVPR54jLB5Fq/JTDQwYHd0Wo6pVyZ5jAYpbztzq+rJ/rpL9ruxTmSoKw==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+      tree_sitter: '*'
+    peerDependenciesMeta:
+      tree_sitter:
+        optional: true
 
   tree-sitter@0.22.4:
     resolution: {integrity: sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==}
@@ -4295,6 +4312,16 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
+
+  tree-sitter-cli@0.23.2: {}
+
+  tree-sitter-swift@0.7.1(tree-sitter@0.22.4):
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
+      tree-sitter: 0.22.4
+      tree-sitter-cli: 0.23.2
+      which: 2.0.2
 
   tree-sitter@0.22.4:
     dependencies:

--- a/tests/indexer/codeintel-swift.spec.ts
+++ b/tests/indexer/codeintel-swift.spec.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../../src/indexer/codeintel.js";
+
+describe("Swift code intelligence", () => {
+  describe("symbol extraction", () => {
+    it("extracts class declaration with methods and properties", () => {
+      const swiftCode = `
+/// A sample class with documentation
+class MyClass {
+  var property: String
+
+  init(value: String) {
+    self.property = value
+  }
+
+  func myMethod() -> String {
+    return property
+  }
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(4);
+
+      // Class
+      expect(result.symbols[0]).toMatchObject({
+        symbolId: 1,
+        name: "MyClass",
+        kind: "class",
+        rangeStartLine: 2,
+        rangeEndLine: 12,
+        doc: "A sample class with documentation",
+      });
+      expect(result.symbols[0]?.signature).toContain("class MyClass");
+
+      // Property
+      expect(result.symbols[1]).toMatchObject({
+        symbolId: 2,
+        name: "property",
+        kind: "property",
+        rangeStartLine: 3,
+        rangeEndLine: 3,
+      });
+
+      // Initializer
+      expect(result.symbols[2]).toMatchObject({
+        symbolId: 3,
+        name: "init",
+        kind: "initializer",
+        rangeStartLine: 5,
+        rangeEndLine: 7,
+      });
+
+      // Method
+      expect(result.symbols[3]).toMatchObject({
+        symbolId: 4,
+        name: "myMethod",
+        kind: "method",
+        rangeStartLine: 9,
+        rangeEndLine: 11,
+      });
+    });
+
+    it("extracts struct declaration", () => {
+      const swiftCode = `
+struct Point {
+  let x: Int
+  let y: Int
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(3);
+      expect(result.symbols[0]).toMatchObject({
+        name: "Point",
+        kind: "struct",
+        rangeStartLine: 1,
+        rangeEndLine: 4,
+      });
+      expect(result.symbols[1]).toMatchObject({
+        name: "x",
+        kind: "property",
+      });
+      expect(result.symbols[2]).toMatchObject({
+        name: "y",
+        kind: "property",
+      });
+    });
+
+    it("extracts protocol declaration with methods", () => {
+      const swiftCode = `
+/// Protocol documentation
+protocol MyProtocol {
+  func protocolMethod()
+  func anotherMethod(param: String) -> Int
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(3);
+      expect(result.symbols[0]).toMatchObject({
+        name: "MyProtocol",
+        kind: "protocol",
+        doc: "Protocol documentation",
+      });
+      expect(result.symbols[1]).toMatchObject({
+        name: "protocolMethod",
+        kind: "protocol_method",
+      });
+      expect(result.symbols[2]).toMatchObject({
+        name: "anotherMethod",
+        kind: "protocol_method",
+      });
+    });
+
+    it("extracts enum declaration with cases", () => {
+      const swiftCode = `
+enum Direction {
+  case north
+  case south
+  case east
+  case west
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(1);
+      expect(result.symbols[0]).toMatchObject({
+        name: "Direction",
+        kind: "enum",
+        rangeStartLine: 1,
+        rangeEndLine: 6,
+      });
+    });
+
+    it("extracts extension declaration", () => {
+      const swiftCode = `
+extension String {
+  var isNotEmpty: Bool {
+    return !self.isEmpty
+  }
+
+  func customMethod() -> Bool {
+    return !self.isEmpty
+  }
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(3);
+      expect(result.symbols[0]).toMatchObject({
+        name: "String",
+        kind: "extension",
+      });
+      expect(result.symbols[1]).toMatchObject({
+        name: "isNotEmpty",
+        kind: "property",
+      });
+      expect(result.symbols[2]).toMatchObject({
+        name: "customMethod",
+        kind: "method",
+      });
+    });
+
+    it("extracts top-level function", () => {
+      const swiftCode = `
+/// Function documentation
+func topLevelFunction(param: Int) -> String {
+  return "\\(param)"
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(1);
+      expect(result.symbols[0]).toMatchObject({
+        name: "topLevelFunction",
+        kind: "function",
+        rangeStartLine: 2,
+        rangeEndLine: 4,
+        doc: "Function documentation",
+      });
+      expect(result.symbols[0]?.signature).toContain("func topLevelFunction");
+    });
+
+    it("handles nested classes and structs", () => {
+      const swiftCode = `
+class OuterClass {
+  struct InnerStruct {
+    let value: Int
+  }
+
+  func outerMethod() {}
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(4);
+      expect(result.symbols[0]).toMatchObject({
+        name: "OuterClass",
+        kind: "class",
+      });
+      expect(result.symbols[1]).toMatchObject({
+        name: "InnerStruct",
+        kind: "struct",
+      });
+      expect(result.symbols[2]).toMatchObject({
+        name: "value",
+        kind: "property",
+      });
+      expect(result.symbols[3]).toMatchObject({
+        name: "outerMethod",
+        kind: "method",
+      });
+    });
+
+    it("extracts generic types", () => {
+      const swiftCode = `
+struct Container<T> {
+  var value: T
+
+  func getValue() -> T {
+    return value
+  }
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(3);
+      expect(result.symbols[0]).toMatchObject({
+        name: "Container",
+        kind: "struct",
+      });
+      expect(result.symbols[0]?.signature).toContain("Container");
+    });
+
+    it("extracts doc comments from block comments", () => {
+      const swiftCode = `
+/**
+ * Multi-line documentation
+ * for a function
+ */
+func documentedFunction() {}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(1);
+      const symbol = result.symbols[0];
+      expect(symbol?.doc).toBeTruthy();
+      if (symbol?.doc) {
+        expect(symbol.doc).toContain("Multi-line documentation");
+        expect(symbol.doc).toContain("for a function");
+      }
+    });
+  });
+
+  describe("snippet generation", () => {
+    it("creates snippets aligned to symbol boundaries", () => {
+      const swiftCode = `
+class MyClass {
+  func method1() {}
+  func method2() {}
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.snippets).toHaveLength(3);
+      expect(result.snippets[0]).toMatchObject({
+        startLine: 1,
+        endLine: 4,
+        symbolId: 1, // MyClass
+      });
+      expect(result.snippets[1]).toMatchObject({
+        startLine: 2,
+        endLine: 2,
+        symbolId: 2, // method1
+      });
+      expect(result.snippets[2]).toMatchObject({
+        startLine: 3,
+        endLine: 3,
+        symbolId: 3, // method2
+      });
+    });
+  });
+
+  describe("dependency analysis", () => {
+    it("extracts import statements as package dependencies", () => {
+      const swiftCode = `
+import Foundation
+import UIKit
+
+class MyClass {}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.dependencies).toHaveLength(2);
+      expect(result.dependencies[0]).toMatchObject({
+        dstKind: "package",
+        dst: "Foundation",
+        rel: "import",
+      });
+      expect(result.dependencies[1]).toMatchObject({
+        dstKind: "package",
+        dst: "UIKit",
+        rel: "import",
+      });
+    });
+
+    it("detects local file imports as path dependencies", () => {
+      const swiftCode = `
+import MyModule
+
+class MyClass {}
+`.trim();
+
+      const fileSet = new Set(["MyModule.swift"]);
+      const result = analyzeSource("test.swift", "Swift", swiftCode, fileSet);
+
+      expect(result.dependencies).toHaveLength(1);
+      expect(result.dependencies[0]).toMatchObject({
+        dstKind: "path",
+        dst: "MyModule.swift",
+        rel: "import",
+      });
+    });
+
+    it("handles multiple import statements", () => {
+      const swiftCode = `
+import Foundation
+import CoreData
+import Combine
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.dependencies).toHaveLength(3);
+      const moduleNames = result.dependencies.map((d) => d.dst);
+      expect(moduleNames).toEqual(["Foundation", "CoreData", "Combine"]);
+    });
+  });
+
+  describe("signature extraction", () => {
+    it("truncates signatures to 200 characters", () => {
+      const longSignature = `
+func veryLongFunctionNameWithManyParameters(param1: String, param2: Int, param3: Bool, param4: Double, param5: Array<String>, param6: Dictionary<String, Any>, param7: Set<Int>, param8: Optional<String>) -> Result<String, Error> {
+  return .success("test")
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", longSignature, new Set());
+
+      expect(result.symbols).toHaveLength(1);
+      const signature = result.symbols[0]?.signature;
+      expect(signature).toBeTruthy();
+      if (signature) {
+        expect(signature.length).toBeLessThanOrEqual(200);
+        expect(signature).toContain("veryLongFunctionNameWithManyParameters");
+      }
+    });
+
+    it("excludes function body from signature", () => {
+      const swiftCode = `
+func myFunction() -> Int {
+  let x = 42
+  return x
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(1);
+      const signature = result.symbols[0]?.signature;
+      expect(signature).toBeTruthy();
+      if (signature) {
+        expect(signature).not.toContain("let x");
+        expect(signature).not.toContain("return x");
+      }
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty results for empty file", () => {
+      const result = analyzeSource("test.swift", "Swift", "", new Set());
+
+      expect(result.symbols).toHaveLength(0);
+      expect(result.snippets).toHaveLength(0);
+      expect(result.dependencies).toHaveLength(0);
+    });
+
+    it("handles files with only imports", () => {
+      const swiftCode = "import Foundation";
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(0);
+      expect(result.dependencies).toHaveLength(1);
+    });
+
+    it("handles symbols without documentation", () => {
+      const swiftCode = `
+class UndocumentedClass {
+  func undocumentedMethod() {}
+}
+`.trim();
+
+      const result = analyzeSource("test.swift", "Swift", swiftCode, new Set());
+
+      expect(result.symbols).toHaveLength(2);
+      expect(result.symbols[0]?.doc).toBeNull();
+      expect(result.symbols[1]?.doc).toBeNull();
+    });
+  });
+});

--- a/tests/server/mcp-standard.spec.ts
+++ b/tests/server/mcp-standard.spec.ts
@@ -160,7 +160,9 @@ describe("MCP標準エンドポイント", () => {
     expect(content[0]).toHaveProperty("text");
 
     // Parse the JSON result and verify it contains search results
-    const searchResults = JSON.parse(content[0].text);
+    const firstContent = content[0];
+    if (!firstContent) throw new Error("Content array is empty");
+    const searchResults = JSON.parse(firstContent.text);
     expect(Array.isArray(searchResults)).toBe(true);
     expect(searchResults.length).toBeGreaterThan(0);
   });
@@ -211,7 +213,9 @@ describe("MCP標準エンドポイント", () => {
 
     const content = result.content as Array<{ type: string; text: string }>;
     expect(Array.isArray(content)).toBe(true);
-    expect(content[0].text).toContain("Unknown tool");
+    const firstContent = content[0];
+    if (!firstContent) throw new Error("Content array is empty");
+    expect(firstContent.text).toContain("Unknown tool");
   });
 
   it("tools/call が無効なパラメータで JSON-RPC エラーを返す", async () => {


### PR DESCRIPTION
## 概要

issue #13 を解決し、KIRIにSwift言語の完全なサポートを追加しました。tree-sitter-swiftを使用したAST解析により、シンボルレベルのコード索引と検索を実現します。

### 主な機能

- **Swift AST解析**: tree-sitter-swiftを使用したシンタックスツリー解析
- **シンボル抽出**: class, struct, protocol, enum, extension, func, init, propertyの抽出
- **シグネチャ抽出**: 200文字制限、関数本体を除外
- **ドキュメントコメント抽出**: `///` と `/** */` 形式の両方に対応
- **インポート依存関係解析**: ローカルファイルとシステムパッケージの区別
- **スレッドセーフ実装**: ファイルごとに新しいパーサーインスタンスを作成
- **堅牢なエラーハンドリング**: 不正なSwiftコードでもクラッシュしない

### 技術的改善

- tree-sitter-swift@0.7.1を依存関係に追加
- 300行以上のSwiftアナライザーを実装
- 18個の包括的テストケース（416行）を作成
- コードカバレッジ83.37%達成（80%要件を超過）
- mcp-standard.spec.tsの型安全性の問題を修正

### クリティカルレビュー修正（Geminiレビューに基づく）

- **並行処理の安全性**: シングルトンパターンを削除し、ファイルごとにパーサーを作成
- **エラーハンドリング**: パーサーの呼び出しをtry-catchでラップ
- **シンボル抽出の完全性**: struct_bodyとextension_bodyのプロパティ抽出を追加

## テスト計画

- [x] ESLintチェック合格
- [x] Prettierフォーマットチェック合格
- [x] TypeScript型チェック合格
- [x] ビルド成功
- [x] 全77テスト合格（14テストファイル）
- [x] コードカバレッジ83.37%達成
- [x] Swift symbol extraction（18テストケース）
  - [x] クラス、構造体、プロトコル、列挙型の抽出
  - [x] 関数、イニシャライザ、プロパティの抽出
  - [x] ネストされた宣言の処理
  - [x] ジェネリック型のサポート
  - [x] ドキュメントコメント抽出（両形式）
  - [x] インポート依存関係解析
  - [x] エッジケースの処理
- [x] Geminiクリティカルレビュー実施済み
- [x] 3つの重大な問題すべて修正済み

## 変更ファイル

- `src/indexer/codeintel.ts` (+304行): Swift analyzer実装
- `tests/indexer/codeintel-swift.spec.ts` (+424行): 包括的テストスイート
- `tests/server/mcp-standard.spec.ts`: 型安全性修正
- `package.json`, `pnpm-lock.yaml`: tree-sitter-swift追加
- `CLAUDE.md`, `README.md`, `docs/indexer.md`: ドキュメント更新

## 関連Issue

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)