### PR TITLE
feat: context_bundle のフィルタリング改善でノイズを削減

### DIFF
--- a/config/scoring-profiles.yml
+++ b/config/scoring-profiles.yml
@@ -2,11 +2,11 @@
 # Each profile defines weights for different ranking signals
 
 default:
-  textMatch: 1.0 # Text/keyword match weight
+  textMatch: 0.8 # Text/keyword match weight (reduced to decrease noise from broad matches)
   editingPath: 2.0 # Currently editing file weight
-  dependency: 0.5 # Dependency relationship weight
+  dependency: 0.6 # Dependency relationship weight (increased to prioritize connected implementation files)
   proximity: 0.25 # Same directory weight
-  structural: 0.75 # Structural similarity weight (LSH-based, not semantic embeddings)
+  structural: 1.0 # Structural similarity weight (increased to improve semantic matching for broad terms)
 
 bugfix:
   textMatch: 1.0

--- a/tests/server/context.bundle.spec.ts
+++ b/tests/server/context.bundle.spec.ts
@@ -50,7 +50,7 @@ describe("context.bundle", () => {
     const repo = await createTempRepo({
       "src/auth/token.ts": `import { calculateExpiry } from "../utils/helper";\n\nexport function verifyToken(token: string): boolean {\n  if (!token) {\n    return false;\n  }\n  const expires = calculateExpiry(token);\n  return Date.now() < expires;\n}\n`,
       "src/utils/helper.ts": `export function calculateExpiry(token: string): number {\n  return token.length * 1000;\n}\n`,
-      "src/auth/token.spec.ts": `import { verifyToken } from "./token";\n\nexport function expectTokenVerifier() {\n  return verifyToken("sample");\n}\n`,
+      "src/auth/validator.ts": `import { verifyToken } from "./token";\n\nexport function validateToken(token: string) {\n  return verifyToken(token);\n}\n`,
     });
     cleanupTargets.push({ dispose: repo.cleanup });
 
@@ -87,7 +87,7 @@ describe("context.bundle", () => {
     expect(helper).toBeDefined();
     expect(helper?.why.some((reason) => reason.startsWith("dep:"))).toBe(true);
 
-    const nearby = bundle.context.find((item) => item.path === "src/auth/token.spec.ts");
+    const nearby = bundle.context.find((item) => item.path === "src/auth/validator.ts");
     expect(nearby).toBeDefined();
     expect(nearby?.why.some((reason) => reason.startsWith("near:"))).toBe(true);
   }, 10000);
@@ -321,5 +321,183 @@ describe("context.bundle", () => {
 
     expect(bundle.context).toBeDefined();
     expect(Array.isArray(bundle.context)).toBe(true);
+  });
+
+  it("filters out test files, config files, and lock files", async () => {
+    const repo = await createTempRepo({
+      "src/auth/login.ts": `export function login(user: string) {\n  return { status: "ok", user };\n}\n`,
+      "src/auth/login.spec.ts": `import { login } from "./login";\n\ntest("login works", () => {\n  expect(login("test")).toBeDefined();\n});\n`,
+      "src/auth/login.test.ts": `import { login } from "./login";\n\ntest("another test", () => {\n  expect(login("test2")).toBeDefined();\n});\n`,
+      "package.json": `{\n  "name": "test",\n  "version": "1.0.0"\n}\n`,
+      "package-lock.json": `{\n  "name": "test",\n  "lockfileVersion": 3\n}\n`,
+      "pnpm-lock.yaml": `lockfileVersion: '9.0'\n`,
+      "tsconfig.json": `{\n  "compilerOptions": {}\n}\n`,
+      "vite.config.ts": `export default {};\n`,
+      ".env": `SECRET=test\n`,
+      Dockerfile: `FROM node:20\n`,
+    });
+    cleanupTargets.push({ dispose: repo.cleanup });
+
+    const dbDir = await mkdtemp(join(tmpdir(), "kiri-db-"));
+    const dbPath = join(dbDir, "index.duckdb");
+    cleanupTargets.push({ dispose: async () => await rm(dbDir, { recursive: true, force: true }) });
+
+    await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+    const db = await DuckDBClient.connect({ databasePath: dbPath });
+    cleanupTargets.push({ dispose: async () => await db.close() });
+
+    const repoId = await resolveRepoId(db, repo.path);
+    const context: ServerContext = { db, repoId };
+
+    const bundle = await contextBundle(context, {
+      goal: "user authentication login implementation",
+      limit: 10,
+    });
+
+    expect(bundle.context.length).toBeGreaterThan(0);
+
+    // Implementation file should be included
+    const loginFile = bundle.context.find((item) => item.path === "src/auth/login.ts");
+    expect(loginFile).toBeDefined();
+
+    // Test files should be filtered out
+    const specFile = bundle.context.find((item) => item.path === "src/auth/login.spec.ts");
+    expect(specFile).toBeUndefined();
+
+    const testFile = bundle.context.find((item) => item.path === "src/auth/login.test.ts");
+    expect(testFile).toBeUndefined();
+
+    // Lock files should be filtered out
+    const packageLock = bundle.context.find((item) => item.path === "package-lock.json");
+    expect(packageLock).toBeUndefined();
+
+    const pnpmLock = bundle.context.find((item) => item.path === "pnpm-lock.yaml");
+    expect(pnpmLock).toBeUndefined();
+
+    // Config files should be filtered out
+    const tsconfig = bundle.context.find((item) => item.path === "tsconfig.json");
+    expect(tsconfig).toBeUndefined();
+
+    const viteConfig = bundle.context.find((item) => item.path === "vite.config.ts");
+    expect(viteConfig).toBeUndefined();
+
+    const packageJson = bundle.context.find((item) => item.path === "package.json");
+    expect(packageJson).toBeUndefined();
+
+    const env = bundle.context.find((item) => item.path === ".env");
+    expect(env).toBeUndefined();
+
+    const dockerfile = bundle.context.find((item) => item.path === "Dockerfile");
+    expect(dockerfile).toBeUndefined();
+  });
+
+  it("filters out blacklisted directories (config, dist, coverage, migrations)", async () => {
+    const repo = await createTempRepo({
+      "src/core/app.ts": `export function main() {\n  return "app";\n}\n`,
+      "config/settings.ts": `export const config = { debug: true };\n`,
+      "dist/bundle.js": `console.log("bundled");\n`,
+      "coverage/report.txt": `Coverage: 80%\n`,
+      "db/migrate/001_init.sql": `CREATE TABLE users (id INT);\n`,
+      "db/migrations/002_add_email.sql": `ALTER TABLE users ADD COLUMN email TEXT;\n`,
+      "build/output.js": `console.log("output");\n`,
+      ".vscode/settings.json": `{ "editor.tabSize": 2 }\n`,
+    });
+    cleanupTargets.push({ dispose: repo.cleanup });
+
+    const dbDir = await mkdtemp(join(tmpdir(), "kiri-db-"));
+    const dbPath = join(dbDir, "index.duckdb");
+    cleanupTargets.push({ dispose: async () => await rm(dbDir, { recursive: true, force: true }) });
+
+    await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+    const db = await DuckDBClient.connect({ databasePath: dbPath });
+    cleanupTargets.push({ dispose: async () => await db.close() });
+
+    const repoId = await resolveRepoId(db, repo.path);
+    const context: ServerContext = { db, repoId };
+
+    const bundle = await contextBundle(context, {
+      goal: "application main function settings config",
+      limit: 10,
+    });
+
+    expect(bundle.context.length).toBeGreaterThan(0);
+
+    // Implementation file should be included
+    const appFile = bundle.context.find((item) => item.path === "src/core/app.ts");
+    expect(appFile).toBeDefined();
+
+    // Blacklisted directories should be filtered out
+    const configFile = bundle.context.find((item) => item.path === "config/settings.ts");
+    expect(configFile).toBeUndefined();
+
+    const distFile = bundle.context.find((item) => item.path === "dist/bundle.js");
+    expect(distFile).toBeUndefined();
+
+    const coverageFile = bundle.context.find((item) => item.path === "coverage/report.txt");
+    expect(coverageFile).toBeUndefined();
+
+    const migration1 = bundle.context.find((item) => item.path === "db/migrate/001_init.sql");
+    expect(migration1).toBeUndefined();
+
+    const migration2 = bundle.context.find(
+      (item) => item.path === "db/migrations/002_add_email.sql"
+    );
+    expect(migration2).toBeUndefined();
+
+    const buildFile = bundle.context.find((item) => item.path === "build/output.js");
+    expect(buildFile).toBeUndefined();
+
+    const vscodeFile = bundle.context.find((item) => item.path === ".vscode/settings.json");
+    expect(vscodeFile).toBeUndefined();
+  });
+
+  it("prioritizes implementation files over documentation with adjusted weights", async () => {
+    const repo = await createTempRepo({
+      "src/app/router.ts": `export function route(path: string) {\n  return { path, component: "Page" };\n}\n`,
+      "README.md": `# Routing Guide\n\nThis explains the routing system and navigation patterns.\n`,
+      "docs/routing.md": `# URL Patterns\n\nHow to access canvas pages through routing.\n`,
+    });
+    cleanupTargets.push({ dispose: repo.cleanup });
+
+    const dbDir = await mkdtemp(join(tmpdir(), "kiri-db-"));
+    const dbPath = join(dbDir, "index.duckdb");
+    cleanupTargets.push({ dispose: async () => await rm(dbDir, { recursive: true, force: true }) });
+
+    await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+    const db = await DuckDBClient.connect({ databasePath: dbPath });
+    cleanupTargets.push({ dispose: async () => await db.close() });
+
+    const repoId = await resolveRepoId(db, repo.path);
+    const context: ServerContext = { db, repoId };
+
+    const bundle = await contextBundle(context, {
+      goal: "Canvas page routing, URL patterns, navigation methods",
+      limit: 10,
+    });
+
+    expect(bundle.context.length).toBeGreaterThan(0);
+
+    // Implementation file should rank higher
+    const routerFile = bundle.context.find((item) => item.path === "src/app/router.ts");
+    expect(routerFile).toBeDefined();
+
+    // If docs are included, they should rank lower
+    const readmeFile = bundle.context.find((item) => item.path === "README.md");
+    const docsFile = bundle.context.find((item) => item.path === "docs/routing.md");
+
+    if (routerFile && readmeFile) {
+      const routerIndex = bundle.context.indexOf(routerFile);
+      const readmeIndex = bundle.context.indexOf(readmeFile);
+      expect(routerIndex).toBeLessThan(readmeIndex);
+    }
+
+    if (routerFile && docsFile) {
+      const routerIndex = bundle.context.indexOf(routerFile);
+      const docsIndex = bundle.context.indexOf(docsFile);
+      expect(routerIndex).toBeLessThan(docsIndex);
+    }
   });
 });


### PR DESCRIPTION
## 概要

`context_bundle` ツールのフィルタリングロジックを改善し、検索結果のノイズを大幅に削減しました。

## 背景

ユーザーからのフィードバックで、以下の問題が報告されました：
- クエリ: "Canvas page routing, URL patterns, navigation methods"
- 問題点:
  - ❌ 広範でノイズが多い: データベースマイグレーション、テストファイル、環境設定が返される
  - ❌ 重要な実装ファイルを見逃す: 実際のルーティングコードが優先されない
  - ⚠️ セマンティック検索が苦戦: "routing"や"navigation"が十分に具体的でない

## 変更内容

### 1. ファイルフィルタリングの強化 (src/server/handlers.ts)

**ブラックリストディレクトリの拡張:**
- `db/migrate/`, `db/migrations/`, `config/`, `dist/`, `build/`, `out/`
- `coverage/`, `.vscode/`, `.idea/`, `tmp/`, `temp/`

**明示的なペナルティスコア:**
- テストファイル (*.spec.ts, *.test.ts): **-2.0**
- ロックファイル (package-lock.json, pnpm-lock.yaml): **-3.0**
- 設定ファイル (tsconfig.json, .env, Dockerfile): **-1.5**
- マイグレーションファイル: **-2.0**

**スコアフィルタリング:**
- スコア ≤ 0 の候補を結果から除外

### 2. スコアリングウェイトの調整 (config/scoring-profiles.yml)

```yaml
textMatch: 1.0 → 0.8    # 広範なキーワードマッチのノイズを削減
structural: 0.75 → 1.0   # 広範なクエリに対するセマンティックマッチングを改善
dependency: 0.5 → 0.6    # 関連する実装ファイルを優先
```

### 3. 包括的なテストカバレッジ

新しいテストを追加:
- ✅ テストファイル、設定ファイル、ロックファイルのフィルタリング
- ✅ ブラックリストディレクトリのフィルタリング (config, dist, coverage, migrations)
- ✅ ドキュメントよりも実装ファイルを優先

## テスト結果

```
✓ 115 tests passed (5 skipped)
✓ 18 test files passed (1 skipped)
✓ Coverage: 59.48% (ベースライン維持)
✓ すべての新しいフィルタリングテストが成功
```

## 期待される効果

元のフィードバックのケース（"Canvas page routing"クエリ）に対して:
- ✅ **実装ファイルが上位にランク**: `src/app/router.ts` が優先される
- ✅ **ノイズファイルを除外**: テスト、マイグレーション、設定ファイル、ロックファイル
- ✅ **精度向上**: 広範なクエリに対するセマンティック検索が強化

## レビュー

Gemini によるコードレビュー:
- ✅ ペナルティスコアは適切に調整されている
- ✅ ブラックリストは JS/TS プロジェクトに対して包括的
- ✅ スコア閾値 (> 0) は効果的で適切
- ✅ 実装品質は高く、テストカバレッジは強力

🤖 Generated with [Claude Code](https://claude.com/claude-code)