### PR TITLE
feat(security): align lock file with database path

### DIFF
--- a/docs/processes/security-review.md
+++ b/docs/processes/security-review.md
@@ -11,7 +11,7 @@
 1. `pnpm exec tsx scripts/diag.ts check-denylist` を実行し、差分が空であることを確認する。
 2. `var/audit/` 配下の最新ログを開き、`path` / `rationale` に `***` マスキングが適用されていることを確認する。
 3. `/metrics` の `kiri_mask_applied_total` と `kiri_denylist_hits_total` を記録し、前週からの増減をトレンドとして残す。
-4. `pnpm exec tsx src/client/cli.ts security verify` を実行し、`state: MATCH` を確認する。
+4. `pnpm exec tsx src/client/cli.ts security verify --db <path/to/index.duckdb>` を実行し、`state: MATCH` を確認する。
 5. 重大な異常が見つかった場合はインシデントチケットを起票し、runbook の手順で対応する。
 
 ## 記録テンプレート

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,8 @@
 
 1. **セキュリティ境界と設定の固定化**
    - `config/security.yml` を追加し、エージェント実行時の権限、アクセス可能なパス、ネットワーク出口の有無を明示する。
-   - `src/server/bootstrap.ts` に起動時バリデーションを実装し、設定の署名ハッシュを `var/security.lock` と比較して改ざんを検知する。
+   - `src/server/bootstrap.ts` に起動時バリデーションを実装し、設定の署名ハッシュを DuckDB と同じディレクトリにある
+     `security.lock` と比較して改ざんを検知する。
    - CLI (`src/client/cli.ts`) からは `security.verify` サブコマンドで現在の適用状況と差分をレポート可能にする。
 
 2. **denylist の二重適用とテスト**

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -4,7 +4,7 @@
 
 1. `/metrics` を確認し、`kiri_http_requests_total` の伸びと 503 レスポンスが増えていないかを確認する。
 2. 監査ログ (`var/audit/*.json`) を開き、直近の `degrade` イベントと対象リポジトリを確認する。
-3. `pnpm exec tsx src/client/cli.ts security verify` を実行し、セキュリティロックに改ざんがないことを確認する。
+3. `pnpm exec tsx src/client/cli.ts security verify --db <path/to/index.duckdb>` を実行し、セキュリティロックに改ざんがないことを確認する。
 4. DuckDB/VSS プロセスのヘルスチェックを行い、必要であれば再起動する。
 5. 復旧が完了したらサーバーを `--allow-degrade` なしで再起動する。復旧完了後に `/metrics` のレスポンスから `degrade: true`
    が含まれないことを確認する。

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,11 +28,12 @@ secrets/**, **/*.pem, **/*.key, **/.env*, **/config/*.prod.*, **/node_modules/**
 - 運用時の権限境界は `config/security.yml` に定義する。`allowed_paths`、`allow_network_egress`、`allow_subprocess` を明示し、
   `sensitive_tokens` にはマスキング対象のトークン接頭辞を列挙する。
 - **スキーマ検証**: 設定ファイルは起動時に Zod スキーマで検証され、必須フィールドの欠落や型エラーがあればサーバー起動をブロックする。
-- 設定ファイルの改ざんを検知するため、`var/security.lock` に SHA-256 ハッシュを保存する。差分がある場合はサーバー起動前に
-  ブロックされる。
-- CLI から `pnpm exec tsx src/client/cli.ts security verify --write-lock` を実行すると現在の設定を検証し、ロックファイルが存在しな
-  ければ生成する。
-- CI では `pnpm exec tsx src/client/cli.ts security verify` を最初のステップとして実行し、差分がないことを保証する。
+- 設定ファイルの改ざんを検知するため、DuckDB ファイル (`index.duckdb`) と同じディレクトリに `security.lock` を保存し、SHA-256
+  ハッシュを照合する。差分がある場合はサーバー起動前にブロックされる。
+- CLI から `pnpm exec tsx src/client/cli.ts security verify --db <path/to/index.duckdb> --write-lock` を実行すると現在の設定を検証し、
+  ロックファイルが存在しなければ生成する。パスを省略した場合は `--db var/index.duckdb` が既定値となる。
+- CI では `pnpm exec tsx src/client/cli.ts security verify --db <path/to/index.duckdb>` を最初のステップとして実行し、差分がないことを
+  保証する。
 
 ## MCP 応答のマスキング
 

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { dirname, join, resolve } from "node:path";
 import process from "node:process";
 
 import { bootstrapServer } from "../server/bootstrap.js";
@@ -7,11 +8,64 @@ import { evaluateSecurityStatus, updateSecurityLock } from "../shared/security/c
 function printUsage(): void {
   console.info(`Usage: pnpm exec tsx src/client/cli.ts <command> [options]\n`);
   console.info(`Commands:`);
-  console.info(`  security verify [--write-lock]    Verify security baseline matches lock file`);
+  console.info(
+    `  security verify [--write-lock] [--db <path>] [--security-lock <path>] [--security-config <path>]`
+  );
+  console.info(`                                       Verify or create security lock`);
 }
 
-function formatStatus(): string {
-  const status = evaluateSecurityStatus();
+interface SecurityVerifyOptions {
+  writeLock: boolean;
+  databasePath: string;
+  securityLockPath?: string;
+  securityConfigPath?: string;
+}
+
+function parseSecurityVerifyArgs(argv: string[]): SecurityVerifyOptions {
+  const options: SecurityVerifyOptions = {
+    writeLock: false,
+    databasePath: "var/index.duckdb",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--write-lock":
+        options.writeLock = true;
+        break;
+      case "--db":
+        if (!argv[i + 1]) {
+          throw new Error("--db requires a path argument");
+        }
+        options.databasePath = argv[i + 1];
+        i += 1;
+        break;
+      case "--security-lock":
+        if (!argv[i + 1]) {
+          throw new Error("--security-lock requires a path argument");
+        }
+        options.securityLockPath = argv[i + 1];
+        i += 1;
+        break;
+      case "--security-config":
+        if (!argv[i + 1]) {
+          throw new Error("--security-config requires a path argument");
+        }
+        options.securityConfigPath = argv[i + 1];
+        i += 1;
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+    }
+  }
+
+  return options;
+}
+
+function formatStatus(securityConfigPath?: string, securityLockPath?: string): string {
+  const status = evaluateSecurityStatus(securityConfigPath, securityLockPath);
   const lockInfo = status.lockHash ? `hash=${status.lockHash}` : "missing";
   const matchState = status.matches ? "MATCH" : "MISMATCH";
   return [
@@ -22,29 +76,41 @@ function formatStatus(): string {
 }
 
 function handleSecurityVerify(argv: string[]): number {
-  const writeLock = argv.includes("--write-lock");
-  const status = evaluateSecurityStatus();
-  if (!status.lockHash && writeLock) {
-    updateSecurityLock(status.hash);
+  let options: SecurityVerifyOptions;
+  try {
+    options = parseSecurityVerifyArgs(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+
+  const resolvedDbPath = resolve(options.databasePath);
+  const resolvedLockPath = options.securityLockPath
+    ? resolve(options.securityLockPath)
+    : join(dirname(resolvedDbPath), "security.lock");
+  const resolvedConfigPath = options.securityConfigPath
+    ? resolve(options.securityConfigPath)
+    : undefined;
+
+  const status = evaluateSecurityStatus(resolvedConfigPath, resolvedLockPath);
+  if (!status.lockHash && options.writeLock) {
+    updateSecurityLock(status.hash, resolvedLockPath);
     console.info("Security lock created.");
-    const refreshed = evaluateSecurityStatus();
-    console.info(
-      [
-        `config: ${refreshed.configPath}`,
-        `lock: ${refreshed.lockPath} (hash=${refreshed.lockHash})`,
-        "state: MATCH",
-      ].join("\n")
-    );
+    console.info(formatStatus(resolvedConfigPath, resolvedLockPath));
     return 0;
   }
   try {
-    bootstrapServer({ allowWriteLock: writeLock });
+    bootstrapServer({
+      allowWriteLock: options.writeLock,
+      securityConfigPath: resolvedConfigPath,
+      securityLockPath: resolvedLockPath,
+    });
     console.info("Security baseline verified.");
-    console.info(formatStatus());
+    console.info(formatStatus(resolvedConfigPath, resolvedLockPath));
     return 0;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
-    console.info(formatStatus());
+    console.info(formatStatus(resolvedConfigPath, resolvedLockPath));
     return 1;
   }
 }

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { tryCreateFTSIndex } from "../indexer/schema.js";
 import { DuckDBClient } from "../shared/duckdb.js";
@@ -29,20 +29,21 @@ export interface ServerRuntime {
 }
 
 export async function createServerRuntime(options: CommonServerOptions): Promise<ServerRuntime> {
+  const databasePath = resolve(options.databasePath);
+  const repoRoot = resolve(options.repoRoot);
+  const defaultLockPath = join(dirname(databasePath), "security.lock");
+
   const bootstrapOptions: BootstrapOptions = {};
   if (options.securityConfigPath) {
     bootstrapOptions.securityConfigPath = options.securityConfigPath;
   }
-  if (options.securityLockPath) {
-    bootstrapOptions.securityLockPath = options.securityLockPath;
-  }
+  bootstrapOptions.securityLockPath = options.securityLockPath
+    ? resolve(options.securityLockPath)
+    : defaultLockPath;
   if (options.allowWriteLock !== undefined) {
     bootstrapOptions.allowWriteLock = options.allowWriteLock;
   }
   const bootstrap = bootstrapServer(bootstrapOptions);
-
-  const databasePath = resolve(options.databasePath);
-  const repoRoot = resolve(options.repoRoot);
 
   let db: DuckDBClient | null = null;
   try {

--- a/tests/client/cli.security.spec.ts
+++ b/tests/client/cli.security.spec.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { main } from "../../src/client/cli.js";
+import { loadSecurityConfig } from "../../src/shared/security/config.js";
+
+describe("CLI security verify", () => {
+  let tempDir: string;
+  const defaultDbName = "index.duckdb";
+  const expectedHash = loadSecurityConfig().hash;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "kiri-cli-test-"));
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates security.lock next to the database when --db is provided", async () => {
+    const dbPath = join(tempDir, defaultDbName);
+    const exitCode = main(["security", "verify", "--db", dbPath, "--write-lock"]);
+
+    expect(exitCode).toBe(0);
+
+    const lockPath = join(tempDir, "security.lock");
+    const lockContent = await readFile(lockPath, "utf-8");
+    expect(lockContent.trim()).toBe(expectedHash);
+  });
+
+  it("honors --security-lock override", async () => {
+    const dbPath = join(tempDir, defaultDbName);
+    const customLock = join(tempDir, "locks", "custom.lock");
+    const exitCode = main([
+      "security",
+      "verify",
+      "--db",
+      dbPath,
+      "--security-lock",
+      customLock,
+      "--write-lock",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    const lockContent = await readFile(customLock, "utf-8");
+    expect(lockContent.trim()).toBe(expectedHash);
+  });
+});

--- a/tests/integration/security.lock.integration.spec.ts
+++ b/tests/integration/security.lock.integration.spec.ts
@@ -1,0 +1,81 @@
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { main as cliMain } from "../../src/client/cli.js";
+import { runIndexer } from "../../src/indexer/cli.js";
+import { createServerRuntime } from "../../src/server/runtime.js";
+import { loadSecurityConfig } from "../../src/shared/security/config.js";
+import { createTempRepo } from "../helpers/test-repo.js";
+
+describe("security lock integration", () => {
+  const cleanupCallbacks: Array<() => Promise<void>> = [];
+  const expectedHash = loadSecurityConfig().hash;
+
+  afterEach(async () => {
+    while (cleanupCallbacks.length > 0) {
+      const cleanup = cleanupCallbacks.pop();
+      if (cleanup) {
+        await cleanup();
+      }
+    }
+  });
+
+  it("allows runtime startup with lock created alongside database", async () => {
+    const repo = await createTempRepo({ "README.md": "# sample\n" });
+    cleanupCallbacks.push(repo.cleanup);
+
+    const dbDir = await mkdtemp(join(tmpdir(), "kiri-integration-db-"));
+    cleanupCallbacks.push(async () => {
+      await rm(dbDir, { recursive: true, force: true });
+    });
+
+    const dbPath = join(dbDir, "index.duckdb");
+    const lockPath = join(dbDir, "security.lock");
+
+    await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+    const exitCode = cliMain(["security", "verify", "--db", dbPath, "--write-lock"]);
+    expect(exitCode).toBe(0);
+
+    await access(lockPath);
+
+    const runtime = await createServerRuntime({ repoRoot: repo.path, databasePath: dbPath });
+    cleanupCallbacks.push(async () => {
+      await runtime.close();
+    });
+
+    const storedHash = (await readFile(lockPath, "utf-8")).trim();
+    expect(storedHash).toBe(expectedHash);
+  });
+
+  it("creates missing lock when allowWriteLock is true", async () => {
+    const repo = await createTempRepo({ "src/app.ts": "export const app = () => 1;\n" });
+    cleanupCallbacks.push(repo.cleanup);
+
+    const dbDir = await mkdtemp(join(tmpdir(), "kiri-integration-db-create-"));
+    cleanupCallbacks.push(async () => {
+      await rm(dbDir, { recursive: true, force: true });
+    });
+
+    const dbPath = join(dbDir, "index.duckdb");
+    const lockPath = join(dbDir, "security.lock");
+
+    await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+    const runtime = await createServerRuntime({
+      repoRoot: repo.path,
+      databasePath: dbPath,
+      allowWriteLock: true,
+    });
+    cleanupCallbacks.push(async () => {
+      await runtime.close();
+    });
+
+    await access(lockPath);
+    const storedHash = (await readFile(lockPath, "utf-8")).trim();
+    expect(storedHash).toBe(expectedHash);
+  });
+});


### PR DESCRIPTION
### 目的
- DuckDB データベースとセキュリティロックの配置を揃え、運用時のロック作成ミスを防ぐ。

### 実装概要
- `src/server/runtime.ts` でデフォルトの `security.lock` をデータベースと同ディレクトリに配置。
- CLI (`kiri security verify`) の引数解析を拡張し、`--db` 指定時に同じディレクトリへロックを作成するよう調整。
- 操作説明・運用ドキュメントを更新。
- 仕様をカバーする CLI/統合テストを追加。

### 検証手順
- `pnpm run test --filter security.lock` を実行し、新規テストが通ることを確認。

### 残課題
- 既存環境の `security.lock` 位置が変わるため、移行ガイドをドキュメント化する。