### PR TITLE
chore(release): v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2025-11-06
+
+### Changed
+
+- Aligned the default `security.lock` location with the DuckDB database path and extended the `kiri security verify` CLI to accept `--db` / `--security-lock` overrides for reproducible deployments.
+- Clarified MCP tool descriptors by documenting output schemas, read-only annotations, and degrade-mode behaviour for `files_search`.
+
+### Fixed
+
+- Ensured `files_search` returns the documented array shape even when DuckDB is unavailable and the server is running in degrade mode, preventing schema mismatches in MCP clients.
+- Added integration coverage that verifies degrade-mode compatibility for MCP `tools/call` responses.
+
 ## [0.9.2] - 2025-11-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Intelligent code context extraction for LLMs via Model Context Protocol
 
-[![Version](https://img.shields.io/badge/version-0.9.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-0.9.3-blue.svg)](package.json)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue.svg)](https://www.typescriptlang.org/)
 [![MCP](https://img.shields.io/badge/MCP-Compatible-green.svg)](https://modelcontextprotocol.io/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiri-mcp-server",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "KIRI context extraction platform",
   "type": "module",
   "packageManager": "pnpm@9.0.0",

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -29,30 +29,42 @@ function parseSecurityVerifyArgs(argv: string[]): SecurityVerifyOptions {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === undefined) {
+      break;
+    }
     switch (arg) {
       case "--write-lock":
         options.writeLock = true;
         break;
       case "--db":
-        if (!argv[i + 1]) {
-          throw new Error("--db requires a path argument");
+        {
+          const dbPath = argv[i + 1];
+          if (!dbPath) {
+            throw new Error("--db requires a path argument");
+          }
+          options.databasePath = dbPath;
+          i += 1;
         }
-        options.databasePath = argv[i + 1];
-        i += 1;
         break;
       case "--security-lock":
-        if (!argv[i + 1]) {
-          throw new Error("--security-lock requires a path argument");
+        {
+          const lockPath = argv[i + 1];
+          if (!lockPath) {
+            throw new Error("--security-lock requires a path argument");
+          }
+          options.securityLockPath = lockPath;
+          i += 1;
         }
-        options.securityLockPath = argv[i + 1];
-        i += 1;
         break;
       case "--security-config":
-        if (!argv[i + 1]) {
-          throw new Error("--security-config requires a path argument");
+        {
+          const configPath = argv[i + 1];
+          if (!configPath) {
+            throw new Error("--security-config requires a path argument");
+          }
+          options.securityConfigPath = configPath;
+          i += 1;
         }
-        options.securityConfigPath = argv[i + 1];
-        i += 1;
         break;
       default:
         if (arg.startsWith("--")) {
@@ -100,11 +112,14 @@ function handleSecurityVerify(argv: string[]): number {
     return 0;
   }
   try {
-    bootstrapServer({
+    const bootstrapOptions: Parameters<typeof bootstrapServer>[0] = {
       allowWriteLock: options.writeLock,
-      securityConfigPath: resolvedConfigPath,
       securityLockPath: resolvedLockPath,
-    });
+    };
+    if (resolvedConfigPath) {
+      bootstrapOptions.securityConfigPath = resolvedConfigPath;
+    }
+    bootstrapServer(bootstrapOptions);
     console.info("Security baseline verified.");
     console.info(formatStatus(resolvedConfigPath, resolvedLockPath));
     return 0;


### PR DESCRIPTION
### 概要
- 0.9.3 リリース準備。セキュリティロック配置変更、MCPツールメタデータ整備、degrade 時の files_search 正規化を含む。

### 含まれる変更
- package.json を 0.9.3 へバンプ。
- CHANGELOG に v0.9.3 エントリ追加。
- CLI のオプション解析を strict TS に合わせて修正。

### チェック項目
- [x] pnpm run check
- [x] pnpm run build

マージ後、[?25l[36m?[39m [1mYou're on branch "release/v0.9.3" but your "publish-branch" is set to "master|main". Do you want to continue?[22m [2m(y/N)[22m [2m›[22m [36mfalse[39m[10D[?25h と  を実施してください。