### PR TITLE
fix(types): TypeScriptビルドエラーを修正

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -433,6 +433,7 @@ export interface ContextBundleParams {
   compact?: boolean; // If true, omit preview field to reduce token usage
   includeTokensEstimate?: boolean; // If true, compute tokens_estimate (slower)
   metadata_filters?: Record<string, string | string[]>;
+  requestId?: string; // Optional request ID for tracing/debugging
 }
 
 export interface ContextBundleItem {
@@ -1377,7 +1378,7 @@ function ensureCandidate(map: Map<string, CandidateInfo>, filePath: string): Can
       pathMatchHits: 0, // Issue #68: Track path match count
       keywordHits: new Set<string>(),
       phraseHits: 0,
-      pathFallbackReason: undefined,
+      // pathFallbackReason は optional なので省略（exactOptionalPropertyTypes対応）
       fallbackTextHits: 0,
       penalties: [], // Issue #68: Penalty log for telemetry
     };


### PR DESCRIPTION
## 概要

v0.12.0リリース準備中に発見されたTypeScriptビルドエラーを修正します。

## 修正内容

- `CandidateInfo` 初期化時の `pathFallbackReason` プロパティを省略
  - `exactOptionalPropertyTypes: true` 設定下では、optional プロパティに `undefined` を明示的に代入できない
- `ContextBundleParams` インターフェースに `requestId?: string` プロパティを追加
  - トレース/デバッグ用のリクエストIDをサポート

## テスト計画

- [x] `pnpm run build` - ビルド成功
- [x] `pnpm run lint` - Lint成功
- [x] `pnpm run test` - 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)