### PR TITLE
feat(docs): shirushiによるドキュメントID管理を導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,29 @@ on:
   pull_request:
 
 jobs:
+  # ドキュメントID検証（ASSAY_KIT_TOKEN不要）
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # shirushi lint --base で差分検出に必要
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Lint documentation IDs
+        run: pnpm docs:lint
+
   build:
     runs-on: ubuntu-latest
     env:

--- a/.shirushi.yml
+++ b/.shirushi.yml
@@ -1,0 +1,33 @@
+# Shirushi Document ID Configuration for KIRI
+#
+# ID形式: {KIND}-{SER3} (例: ARCH-001, ADR-001, RUN-001)
+# ドキュメントの一意識別子を管理し、変更を検出する
+
+doc_globs:
+  - "docs/**/*.md"
+  - "!docs/formal/**" # TLA+/Alloy formal specs を除外
+  - "!docs/eval-*.md" # 評価レポートを除外
+  - "!docs/refactoring-analysis-*.md" # 分析レポートを除外
+
+index_file: "docs/doc_index.yaml"
+id_field: "doc_id"
+id_format: "{KIND}-{SER3}"
+
+dimensions:
+  KIND:
+    type: enum
+    values:
+      - ARCH # Architecture - コア設計とリファレンス
+      - ADR # Architecture Decision Record - 設計決定
+      - RUN # Runbook - 運用手順
+      - GUIDE # Guide - ユーザー/開発者向けガイド
+      - SEC # Security - セキュリティドキュメント
+      - TEST # Testing - テスト戦略
+      - PLAN # Planning - ロードマップと計画
+  SER3:
+    type: serial
+    digits: 3
+    scope: ["KIND"]
+
+forbid_id_change: true
+allow_missing_id_in_new_files: false

--- a/docs/adr/ADR-001-graduated-penalty-system.md
+++ b/docs/adr/ADR-001-graduated-penalty-system.md
@@ -1,4 +1,16 @@
-# ADR 002: Graduated Penalty System for Path-Based Scoring
+---
+doc_id: "ADR-001"
+title: "Graduated Penalty System for Path-Based Scoring"
+category: "adr"
+tags:
+  - adr
+  - penalty
+  - scoring
+  - path-matching
+service: "kiri"
+---
+
+# ADR 001: Graduated Penalty System for Path-Based Scoring
 
 **Status**: Accepted
 **Date**: 2025-11-12 (Proposed), 2025-11-12 (Accepted)

--- a/docs/adr/ADR-002-abbreviation-expansion-for-path-matching.md
+++ b/docs/adr/ADR-002-abbreviation-expansion-for-path-matching.md
@@ -1,13 +1,25 @@
-# ADR 003: Abbreviation Expansion for Path Matching
+---
+doc_id: "ADR-002"
+title: "Abbreviation Expansion for Path Matching"
+category: "adr"
+tags:
+  - adr
+  - path-matching
+  - abbreviation
+  - scoring
+service: "kiri"
+---
+
+# ADR 002: Abbreviation Expansion for Path Matching
 
 **Status**: Accepted
 **Date**: 2025-11-12
 **Deciders**: Issue #68 investigation team
-**Related**: ADR 002 (Graduated Penalty System)
+**Related**: ADR 001 (Graduated Penalty System)
 
 ## Context
 
-After implementing the graduated penalty system (ADR 002), telemetry analysis revealed:
+After implementing the graduated penalty system (ADR 001), telemetry analysis revealed:
 
 - **90.1% of candidates have zero path matches** (pathMatchHits === 0)
 - P@10 improvement was only +4.2% (0.189 → 0.197)
@@ -297,7 +309,7 @@ Verify pathMatchHits distribution improves after abbreviation expansion.
 
 ## Evaluation Results (2025-11-12)
 
-Implemented and evaluated per ADR 003 recommendations. Results showed:
+Implemented and evaluated per ADR 002 recommendations. Results showed:
 
 1. ✅ **Implementation quality**: LDE-compliant, 19/19 property tests passing
 2. ✅ **Performance**: <1ms overhead, well within budget
@@ -347,6 +359,6 @@ Path-based matching has reached practical limits with current approach. For sign
 ## References
 
 - Issue #68: Path and Large File Penalty System
-- ADR 002: Graduated Penalty System
+- ADR 001: Graduated Penalty System
 - Telemetry analysis: `/var/eval/issue-68-investigation-final.md`
 - Critical review: `/tmp/fuzzy-path-critical-review.md`

--- a/docs/api-and-client.md
+++ b/docs/api-and-client.md
@@ -1,3 +1,14 @@
+---
+doc_id: "ARCH-004"
+title: "MCP API and Client Configuration"
+category: "architecture"
+tags:
+  - api
+  - mcp
+  - client
+service: "kiri"
+---
+
 # MCP API and Client Configuration
 
 ## Overview

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,3 +1,14 @@
+---
+doc_id: "ARCH-002"
+title: "データモデル（DuckDB スキーマ）"
+category: "architecture"
+tags:
+  - schema
+  - duckdb
+  - data-model
+service: "kiri"
+---
+
 # データモデル（DuckDB スキーマ）
 
 > ポイント: **blob/tree 分離**でリネームに強く重複本文を排除。VSS/FTS はオプションで、Degrade 運転時は無効でも成立する設計とする。

--- a/docs/dev/node-version.md
+++ b/docs/dev/node-version.md
@@ -1,3 +1,14 @@
+---
+doc_id: "GUIDE-005"
+title: "Node バージョンとツールチェーン"
+category: "development"
+tags:
+  - node
+  - toolchain
+  - setup
+service: "kiri"
+---
+
 # Node バージョンとツールチェーン
 
 - 推奨 Node: **20.x (LTS)**

--- a/docs/dev/path-penalties.md
+++ b/docs/dev/path-penalties.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "GUIDE-004"
 title: "Path Penalties Developer Notes"
 category: "configuration"
 tags:

--- a/docs/doc_index.yaml
+++ b/docs/doc_index.yaml
@@ -1,0 +1,81 @@
+# KIRI Document Index
+# shirushi によって管理されるドキュメントID一覧
+# 形式: {KIND}-{SER3} (例: ARCH-001)
+
+documents:
+  # Architecture - コア設計とリファレンス
+  - doc_id: ARCH-001
+    path: docs/overview.md
+    title: "KIRI 概要"
+  - doc_id: ARCH-002
+    path: docs/data-model.md
+    title: "データモデル（DuckDB スキーマ）"
+  - doc_id: ARCH-003
+    path: docs/indexer.md
+    title: "Indexer"
+  - doc_id: ARCH-004
+    path: docs/api-and-client.md
+    title: "API & Client"
+  - doc_id: ARCH-005
+    path: docs/search-ranking.md
+    title: "検索とランキング"
+  - doc_id: ARCH-006
+    path: docs/schema-migrations.md
+    title: "Schema Migrations"
+  - doc_id: ARCH-007
+    path: docs/dynamic-profile-selection.md
+    title: "Dynamic Profile Selection"
+
+  # ADR - Architecture Decision Records
+  - doc_id: ADR-001
+    path: docs/adr/ADR-001-graduated-penalty-system.md
+    title: "Graduated Penalty System"
+  - doc_id: ADR-002
+    path: docs/adr/ADR-002-abbreviation-expansion-for-path-matching.md
+    title: "Abbreviation Expansion for Path Matching"
+
+  # Runbook - 運用手順
+  - doc_id: RUN-001
+    path: docs/runbook.md
+    title: "運用 Runbook"
+  - doc_id: RUN-002
+    path: docs/operations.md
+    title: "Operations"
+
+  # Guide - ユーザー/開発者向けガイド
+  - doc_id: GUIDE-001
+    path: docs/documentation-best-practices.md
+    title: "Documentation Best Practices"
+  - doc_id: GUIDE-002
+    path: docs/user/path-penalties.md
+    title: "Path Penalties User Guide"
+  - doc_id: GUIDE-003
+    path: docs/user/path-penalties.ja.md
+    title: "Path Penalties ユーザーガイド（日本語）"
+  - doc_id: GUIDE-004
+    path: docs/dev/path-penalties.md
+    title: "Path Penalties Developer Guide"
+  - doc_id: GUIDE-005
+    path: docs/dev/node-version.md
+    title: "Node Version Requirements"
+
+  # Security - セキュリティドキュメント
+  - doc_id: SEC-001
+    path: docs/security.md
+    title: "セキュリティとコンプライアンス"
+  - doc_id: SEC-002
+    path: docs/processes/security-review.md
+    title: "Security Review Process"
+
+  # Testing - テスト戦略
+  - doc_id: TEST-001
+    path: docs/testing.md
+    title: "テストと評価"
+
+  # Planning - ロードマップと計画
+  - doc_id: PLAN-001
+    path: docs/roadmap.md
+    title: "Roadmap"
+  - doc_id: PLAN-002
+    path: docs/principles.md
+    title: "開発原則と未解決課題"

--- a/docs/documentation-best-practices.md
+++ b/docs/documentation-best-practices.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "GUIDE-001"
 title: "Authoring Docs for KIRI Search"
 category: "docs"
 tags:

--- a/docs/dynamic-profile-selection.md
+++ b/docs/dynamic-profile-selection.md
@@ -1,3 +1,14 @@
+---
+doc_id: "ARCH-007"
+title: "動的プロファイル選択機能"
+category: "architecture"
+tags:
+  - profile
+  - selection
+  - ranking
+service: "kiri"
+---
+
 # 動的プロファイル選択機能
 
 **導入日**: 2025-11-17  

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -1,3 +1,14 @@
+---
+doc_id: "ARCH-003"
+title: "取り込みパイプライン（Indexer）"
+category: "architecture"
+tags:
+  - indexer
+  - pipeline
+  - tree-sitter
+service: "kiri"
+---
+
 # 取り込みパイプライン（Indexer）
 
 ## ステップ概要

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "RUN-002"
 title: "運用と可観測性"
 category: "operations"
 tags:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "ARCH-001"
 title: "KIRI 概要"
 category: "architecture"
 tags:

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,3 +1,14 @@
+---
+doc_id: "PLAN-002"
+title: "開発原則と未解決課題"
+category: "planning"
+tags:
+  - principles
+  - guidelines
+  - issues
+service: "kiri"
+---
+
 # 開発原則と未解決課題
 
 ## 開発上の決めごと

--- a/docs/processes/security-review.md
+++ b/docs/processes/security-review.md
@@ -1,3 +1,14 @@
+---
+doc_id: "SEC-002"
+title: "セキュリティレビュー手順"
+category: "security"
+tags:
+  - security
+  - review
+  - process
+service: "kiri"
+---
+
 # セキュリティレビュー手順
 
 ## 週次レビューの目的

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,14 @@
+---
+doc_id: "PLAN-001"
+title: "実装マイルストーンと依存関係"
+category: "planning"
+tags:
+  - roadmap
+  - milestone
+  - planning
+service: "kiri"
+---
+
 # 実装マイルストーンと依存関係
 
 ## マイルストーン

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "RUN-001"
 title: "運用 Runbook"
 category: "operations"
 tags:

--- a/docs/schema-migrations.md
+++ b/docs/schema-migrations.md
@@ -1,3 +1,14 @@
+---
+doc_id: "ARCH-006"
+title: "DuckDB Schema Migrations"
+category: "architecture"
+tags:
+  - schema
+  - migration
+  - duckdb
+service: "kiri"
+---
+
 # DuckDB Schema Migrations
 
 > KIRIは自動スキーママイグレーションを使用します。既存のデータベースに対して新しいテーブルやカラムが自動的に追加されます。

--- a/docs/search-ranking.md
+++ b/docs/search-ranking.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "ARCH-005"
 title: "検索とランキング"
 category: "search"
 tags:

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "SEC-001"
 title: "セキュリティとコンプライアンス"
 category: "security"
 tags:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "TEST-001"
 title: "テストと評価"
 category: "testing"
 tags:

--- a/docs/user/path-penalties.ja.md
+++ b/docs/user/path-penalties.ja.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "GUIDE-003"
 title: "Path Penalties ユーザーガイド"
 category: "configuration"
 tags:

--- a/docs/user/path-penalties.md
+++ b/docs/user/path-penalties.md
@@ -1,4 +1,5 @@
 ---
+doc_id: "GUIDE-002"
 title: "Path Penalties User Guide"
 category: "configuration"
 tags:

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "assay:report-matrix": "tsx scripts/assay/report-matrix.ts",
     "check:adaptive-k": "tsx scripts/check-adaptive-k.ts",
     "check": "pnpm run lint && pnpm run test",
+    "docs:lint": "node scripts/docs/lint.mjs",
+    "docs:scan": "node scripts/docs/scan.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
@@ -105,6 +107,7 @@
     "nock": "^13",
     "openai": "^4",
     "prettier": "^3.3.3",
+    "shirushi": "^0.1.0",
     "simple-git-hooks": "^2.10.0",
     "tsx": "^4.16.5",
     "undici": "^6",
@@ -116,6 +119,9 @@
   "lint-staged": {
     "*.{ts,tsx,json,md,yml}": [
       "pnpm exec prettier --write"
+    ],
+    "docs/**/*.md": [
+      "pnpm docs:lint"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
+      shirushi:
+        specifier: ^0.1.0
+        version: 0.1.0
       simple-git-hooks:
         specifier: ^2.10.0
         version: 2.13.1
@@ -667,6 +670,14 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -687,6 +698,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1196,6 +1213,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1315,6 +1335,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -1516,6 +1540,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -1553,6 +1582,10 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   fast-check@4.3.0:
     resolution: {integrity: sha512-JVw/DJSxVKl8uhCb7GrwanT9VWsCIdBkK3WpP37B/Au4pyaspriSjtrY2ApbSFwTg3ViPfniT13n75PhzE7VEQ==}
@@ -1619,6 +1652,9 @@ packages:
   formdata-node@4.4.1:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
+
+  fp-ts@2.16.11:
+    resolution: {integrity: sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1699,6 +1735,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -1796,6 +1836,10 @@ packages:
   is-date-object@1.1.0:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1918,6 +1962,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1940,6 +1988,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2015,6 +2067,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2285,6 +2341,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2314,6 +2374,11 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shirushi@0.1.0:
+    resolution: {integrity: sha512-bW15YwmT8ADCsphTKkzDlMsEOdDw1jdKbgbp08KujwZGOIYEHCti5sWxeWppOEBGMTufFXERzuLiybcrZ7Yi/g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -2341,6 +2406,9 @@ packages:
     resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
     hasBin: true
 
+  simple-git@3.30.0:
+    resolution: {integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -2352,6 +2420,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2398,6 +2469,10 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2677,6 +2752,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
@@ -3413,6 +3491,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3437,6 +3521,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4068,6 +4160,10 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   array-buffer-byte-length@1.0.2:
@@ -4209,6 +4305,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@11.1.0: {}
 
   commander@13.1.0: {}
 
@@ -4537,6 +4635,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -4585,6 +4685,10 @@ snapshots:
       yoctocolors: 2.1.2
 
   expect-type@1.2.2: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   fast-check@4.3.0:
     dependencies:
@@ -4659,6 +4763,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
+
+  fp-ts@2.16.11: {}
 
   fsevents@2.3.3:
     optional: true
@@ -4746,6 +4852,13 @@ snapshots:
   gpt-tokenizer@3.2.0: {}
 
   graphemer@1.4.0: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   has-bigints@1.1.0: {}
 
@@ -4840,6 +4953,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -4956,6 +5071,11 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -4975,6 +5095,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   levn@0.4.1:
     dependencies:
@@ -5059,6 +5181,10 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
+
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.1.2:
     dependencies:
@@ -5342,6 +5468,11 @@ snapshots:
   safer-buffer@2.1.2:
     optional: true
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1: {}
 
   semver@7.7.3: {}
@@ -5373,6 +5504,21 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shirushi@0.1.0:
+    dependencies:
+      chalk: 5.6.2
+      commander: 11.1.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fp-ts: 2.16.11
+      gray-matter: 4.0.3
+      js-yaml: 4.1.0
+      minimatch: 10.1.1
+      simple-git: 3.30.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
 
   side-channel-list@1.0.0:
     dependencies:
@@ -5408,6 +5554,14 @@ snapshots:
 
   simple-git-hooks@2.13.1: {}
 
+  simple-git@3.30.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -5419,6 +5573,8 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
+
+  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
@@ -5479,6 +5635,8 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 
@@ -5771,5 +5929,7 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod@3.25.76: {}
 
   zod@4.1.12: {}

--- a/scripts/docs/lint.mjs
+++ b/scripts/docs/lint.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Shirushi CLI wrapper for document ID validation
+ *
+ * Workaround: shirushi's CLI uses import.meta.url check which fails
+ * with symlinked node_modules on macOS due to path canonicalization.
+ * This wrapper explicitly calls run() to bypass the check.
+ */
+
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { realpathSync } from 'fs';
+
+// Set up argv for subcommand
+process.argv = ['node', 'shirushi', 'lint', ...process.argv.slice(2)];
+
+// Resolve the actual path to shirushi CLI (follows symlinks)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '../..');
+const shirushiCliPath = realpathSync(
+  resolve(projectRoot, 'node_modules/shirushi/dist/cli/index.js')
+);
+
+// Dynamic import using file URL to match import.meta.url check
+const { run } = await import(`file://${shirushiCliPath}`);
+run();

--- a/scripts/docs/scan.mjs
+++ b/scripts/docs/scan.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Shirushi CLI wrapper for document scanning
+ *
+ * Workaround: shirushi's CLI uses import.meta.url check which fails
+ * with symlinked node_modules on macOS due to path canonicalization.
+ * This wrapper explicitly calls run() to bypass the check.
+ */
+
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { realpathSync } from 'fs';
+
+// Set up argv for subcommand
+process.argv = ['node', 'shirushi', 'scan', ...process.argv.slice(2)];
+
+// Resolve the actual path to shirushi CLI (follows symlinks)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '../..');
+const shirushiCliPath = realpathSync(
+  resolve(projectRoot, 'node_modules/shirushi/dist/cli/index.js')
+);
+
+// Dynamic import using file URL to match import.meta.url check
+const { run } = await import(`file://${shirushiCliPath}`);
+run();


### PR DESCRIPTION
## 概要

shirushi（https://github.com/CAPHTECH/shirushi）を使用して、kiriのドキュメントにID管理システムを導入しました。

## 変更内容

### 設定ファイル
- `.shirushi.yml`: ID形式 `{KIND}-{SER3}` を定義（例: ARCH-001, ADR-002）
- `docs/doc_index.yaml`: 21件のドキュメントIDを集中管理

### ドキュメント
- 全17件のマークダウンファイルに `doc_id` フロントマターを追加
- ADRファイル名をID形式にリネーム:
  - `002-graduated-penalty-system.md` → `ADR-001-graduated-penalty-system.md`
  - `003-abbreviation-expansion-for-path-matching.md` → `ADR-002-abbreviation-expansion-for-path-matching.md`

### ID種別（KIND）
| KIND | 用途 |
|------|------|
| ARCH | アーキテクチャ（コア設計とリファレンス） |
| ADR | Architecture Decision Record |
| RUN | Runbook（運用手順） |
| GUIDE | ユーザー/開発者向けガイド |
| SEC | セキュリティドキュメント |
| TEST | テスト戦略 |
| PLAN | ロードマップと計画 |

### CI/開発ワークフロー
- GitHub Actions: `docs` ジョブを追加（PRでバリデーションエラー時にブロック）
- lint-staged: `docs/**/*.md` 変更時に `pnpm docs:lint` を自動実行
- `pnpm docs:lint`: ドキュメントIDバリデーション
- `pnpm docs:scan`: ドキュメント一覧表示

### 技術的対応
- `scripts/docs/*.mjs`: macOS symlink問題の回避ラッパースクリプト
  - Node.js の `import.meta.url` がシンボリックリンク経由で正規パスと一致しない問題への対処

## テスト計画

- [x] `pnpm docs:lint` が成功することを確認
- [x] 不正なドキュメントで `pnpm docs:lint` が失敗（exit 1）することを確認
- [x] `pnpm docs:scan` が全21件のドキュメントを表示することを確認
- [x] lint-stagedがpre-commitで正しく動作することを確認
- [ ] CI上で `docs` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)