### PR TITLE
fix: persistDocumentMetadataのJSON出力に防御的サニタイズを追加 (Issue #141)

### DIFF
--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -582,7 +582,8 @@ async function persistDocumentMetadata(
       repoId,
       record.path,
       record.source,
-      JSON.stringify(record.data),
+      // 防御的サニタイズ: JSON.stringify結果に孤立サロゲートが含まれる可能性に対応 (Issue #141)
+      sanitizeSurrogates(JSON.stringify(record.data), "document_metadata JSON"),
     ]),
   }));
 }


### PR DESCRIPTION
## 概要

`document_metadata`テーブルへのINSERT時に`Malformed JSON at byte X: no low surrogate in string`エラーが発生するエッジケースに対応します。

## 問題

- kakusillリポジトリのインデックス作成時に、97レコードのバッチ処理で孤立サロゲートによるJSONエラーが発生
- Issue #141で`sanitizeMetadataTree`内にサロゲート処理は追加済みだが、`JSON.stringify()`の出力自体にもサニタイズが必要な可能性

## 解決策

`persistDocumentMetadata`関数で`JSON.stringify(record.data)`の結果に対して`sanitizeSurrogates()`を適用する防御的サニタイズを追加。

```typescript
sanitizeSurrogates(JSON.stringify(record.data), "document_metadata JSON"),
```

## テスト計画

- [x] 既存のメタデータテストが全てパスすることを確認（23テスト成功）
- [x] サロゲート処理関連のテストが正常に動作することを確認
- [ ] kakusillリポジトリでインデックス再作成が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)