### PR TITLE
feat: MCP 2025-06-18 Structured Output対応 (Issue #144)

### DIFF
--- a/src/server/output-schemas.ts
+++ b/src/server/output-schemas.ts
@@ -1,0 +1,145 @@
+/**
+ * MCP Structured Output用のoutputSchema定義
+ *
+ * Zod 4のz.toJSONSchema()を使用して、各ツールの戻り値のJSON Schemaを生成。
+ * MCP仕様（2025-06-18）のstructuredContent対応に使用。
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+ * @see https://zod.dev/json-schema
+ */
+import { z } from "zod";
+
+// =============================================================================
+// context_bundle
+// =============================================================================
+
+/**
+ * context_bundleの各エントリのスキーマ
+ */
+export const ContextBundleItemSchema = z.object({
+  path: z.string().describe("ファイルパス"),
+  range: z.tuple([z.number(), z.number()]).describe("行範囲 [start, end]"),
+  preview: z.string().optional().describe("コードプレビュー（compact=falseの場合）"),
+  why: z.array(z.string()).describe("スコアリング理由"),
+  score: z.number().describe("関連度スコア"),
+});
+
+/**
+ * context_bundleの戻り値スキーマ
+ */
+export const ContextBundleResultSchema = z.object({
+  context: z.array(ContextBundleItemSchema).describe("関連コードスニペットの配列"),
+  tokens_estimate: z.number().optional().describe("推定トークン数"),
+  warnings: z.array(z.string()).optional().describe("警告メッセージ"),
+});
+
+// =============================================================================
+// files_search
+// =============================================================================
+
+/**
+ * files_searchの各エントリのスキーマ
+ */
+export const FilesSearchResultItemSchema = z.object({
+  path: z.string().describe("ファイルパス"),
+  preview: z.string().optional().describe("マッチしたコンテキスト（compact=falseの場合）"),
+  matchLine: z.number().describe("マッチした行番号"),
+  lang: z.string().nullable().describe("プログラミング言語"),
+  ext: z.string().nullable().describe("ファイル拡張子"),
+  score: z.number().describe("検索スコア"),
+});
+
+/**
+ * files_searchの戻り値スキーマ（配列）
+ */
+export const FilesSearchResultSchema = z.array(FilesSearchResultItemSchema);
+
+// =============================================================================
+// snippets_get
+// =============================================================================
+
+/**
+ * snippets_getの戻り値スキーマ
+ */
+export const SnippetResultSchema = z.object({
+  path: z.string().describe("ファイルパス"),
+  startLine: z.number().describe("開始行番号"),
+  endLine: z.number().describe("終了行番号"),
+  content: z.string().optional().describe("スニペット内容（compact=falseの場合）"),
+  totalLines: z.number().describe("ファイルの総行数"),
+  symbolName: z.string().nullable().describe("シンボル名"),
+  symbolKind: z.string().nullable().describe("シンボル種別"),
+  truncated: z.boolean().optional().describe("ファイルが切り詰められたか（view=fullの場合）"),
+});
+
+// =============================================================================
+// deps_closure
+// =============================================================================
+
+/**
+ * deps_closureのノードスキーマ
+ */
+export const DepsClosureNodeSchema = z.object({
+  kind: z.enum(["path", "package"]).describe("ノード種別"),
+  target: z.string().describe("対象パスまたはパッケージ名"),
+  depth: z.number().describe("ルートからの深さ"),
+});
+
+/**
+ * deps_closureのエッジスキーマ
+ */
+export const DepsClosureEdgeSchema = z.object({
+  from: z.string().describe("依存元"),
+  to: z.string().describe("依存先"),
+  kind: z.enum(["path", "package"]).describe("エッジ種別"),
+  rel: z.string().describe("関係タイプ"),
+  depth: z.number().describe("エッジの深さ"),
+});
+
+/**
+ * deps_closureの戻り値スキーマ
+ */
+export const DepsClosureResultSchema = z.object({
+  root: z.string().describe("ルートファイルパス"),
+  direction: z.enum(["outbound", "inbound"]).describe("探索方向"),
+  nodes: z.array(DepsClosureNodeSchema).describe("依存ノード配列"),
+  edges: z.array(DepsClosureEdgeSchema).describe("依存エッジ配列"),
+});
+
+// =============================================================================
+// semantic_rerank
+// =============================================================================
+
+/**
+ * semantic_rerankの各エントリのスキーマ
+ */
+export const SemanticRerankItemSchema = z.object({
+  path: z.string().describe("ファイルパス"),
+  semantic: z.number().describe("セマンティック類似度スコア"),
+  base: z.number().describe("ベーススコア"),
+  combined: z.number().describe("統合スコア"),
+});
+
+/**
+ * semantic_rerankの戻り値スキーマ
+ */
+export const SemanticRerankResultSchema = z.object({
+  candidates: z.array(SemanticRerankItemSchema).describe("リランキングされた候補配列"),
+});
+
+// =============================================================================
+// JSON Schema生成
+// =============================================================================
+
+/**
+ * 各ツールのoutputSchemaをJSON Schema形式で生成
+ *
+ * MCP仕様のtools/listレスポンスで使用される
+ */
+export const OUTPUT_SCHEMAS = {
+  context_bundle: z.toJSONSchema(ContextBundleResultSchema),
+  files_search: z.toJSONSchema(FilesSearchResultSchema),
+  snippets_get: z.toJSONSchema(SnippetResultSchema),
+  deps_closure: z.toJSONSchema(DepsClosureResultSchema),
+  semantic_rerank: z.toJSONSchema(SemanticRerankResultSchema),
+} as const;

--- a/src/server/rpc.ts
+++ b/src/server/rpc.ts
@@ -26,6 +26,7 @@ import {
 } from "./handlers.js";
 import { MetricsRegistry } from "./observability/metrics.js";
 import { withSpan } from "./observability/tracing.js";
+import { OUTPUT_SCHEMAS } from "./output-schemas.js";
 import { selectProfileFromQuery } from "./profile-selector.js";
 
 const RESPONSE_MASK_SKIP_KEYS = ["path"];
@@ -196,6 +197,7 @@ interface ToolDescriptor {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>; // MCP 2025-06-18: Structured Output対応
 }
 
 const SERVER_INFO = {
@@ -310,6 +312,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         },
       },
     },
+    outputSchema: OUTPUT_SCHEMAS.context_bundle,
   },
   {
     name: "semantic_rerank",
@@ -339,6 +342,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         profile: { type: "string" },
       },
     },
+    outputSchema: OUTPUT_SCHEMAS.semantic_rerank,
   },
   {
     name: "files_search",
@@ -401,6 +405,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         },
       },
     },
+    outputSchema: OUTPUT_SCHEMAS.files_search,
   },
   {
     name: "snippets_get",
@@ -442,6 +447,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         },
       },
     },
+    outputSchema: OUTPUT_SCHEMAS.snippets_get,
   },
   {
     name: "deps_closure",
@@ -463,6 +469,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
         include_packages: { type: "boolean" },
       },
     },
+    outputSchema: OUTPUT_SCHEMAS.deps_closure,
   },
 ];
 
@@ -816,12 +823,13 @@ export function validateJsonRpcRequest(payload: JsonRpcRequest): string | null {
   return null;
 }
 
-// MCP standard tool result format
+// MCP standard tool result format (MCP 2025-06-18: Structured Output対応)
 interface McpToolResult {
   content: Array<{
     type: "text";
     text: string;
   }>;
+  structuredContent?: unknown; // MCP 2025-06-18: 構造化レスポンス
   isError?: boolean;
 }
 
@@ -967,7 +975,7 @@ export function createRpcHandler(
               allowDegrade
             );
 
-            // Convert to MCP standard format
+            // Convert to MCP standard format (MCP 2025-06-18: Structured Output対応)
             const mcpResult: McpToolResult = {
               content: [
                 {
@@ -975,6 +983,7 @@ export function createRpcHandler(
                   text: JSON.stringify(toolResult, null, 2),
                 },
               ],
+              structuredContent: toolResult, // MCP 2025-06-18: 構造化レスポンス
               isError: false,
             };
             result = mcpResult;

--- a/tests/server/mcp-standard.spec.ts
+++ b/tests/server/mcp-standard.spec.ts
@@ -673,4 +673,235 @@ describe("MCP標準エンドポイント", () => {
       expect(searchResults.every((item) => item.preview === undefined)).toBe(true);
     });
   });
+
+  // MCP 2025-06-18 Structured Output 対応テスト
+  describe("MCP 2025-06-18 Structured Output", () => {
+    it("tools/list の全ツールに outputSchema が含まれる", async () => {
+      const repo = await createTempRepo({
+        "src/app.ts": "export const app = () => 1;\n",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-mcp-output-schema-"));
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      const dbPath = join(dbDir, "index.duckdb");
+      const lockPath = join(dbDir, "security.lock");
+      const { hash } = loadSecurityConfig();
+      updateSecurityLock(hash, lockPath);
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const runtime = await createServerRuntime({
+        repoRoot: repo.path,
+        databasePath: dbPath,
+        securityLockPath: lockPath,
+      });
+      cleanupTargets.push({ dispose: async () => await runtime.close() });
+
+      const handler = createRpcHandler(runtime);
+      const request: JsonRpcRequest = { jsonrpc: "2.0", id: 200, method: "tools/list" };
+      const response = ensureResponse(await handler(request));
+
+      expect(response.statusCode).toBe(200);
+      const payload = response.response as JsonRpcSuccess;
+      const tools = (payload.result as Record<string, unknown>).tools as unknown[];
+      expect(Array.isArray(tools)).toBe(true);
+
+      // 全5ツールにoutputSchemaが含まれることを検証
+      const expectedTools = [
+        "context_bundle",
+        "semantic_rerank",
+        "files_search",
+        "snippets_get",
+        "deps_closure",
+      ];
+
+      for (const expectedToolName of expectedTools) {
+        const tool = tools.find(
+          (t) =>
+            t && typeof t === "object" && (t as Record<string, unknown>).name === expectedToolName
+        ) as Record<string, unknown> | undefined;
+
+        expect(tool).toBeDefined();
+        expect(tool?.outputSchema).toBeDefined();
+        expect(typeof tool?.outputSchema).toBe("object");
+        expect((tool?.outputSchema as Record<string, unknown>)?.type).toBeDefined();
+      }
+    });
+
+    it("tools/call が structuredContent を含むレスポンスを返す", async () => {
+      const repo = await createTempRepo({
+        "src/main.ts": "export function hello() {\n  return 'world';\n}\n",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-mcp-structured-content-"));
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      const dbPath = join(dbDir, "index.duckdb");
+      const lockPath = join(dbDir, "security.lock");
+      const { hash } = loadSecurityConfig();
+      updateSecurityLock(hash, lockPath);
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const runtime = await createServerRuntime({
+        repoRoot: repo.path,
+        databasePath: dbPath,
+        securityLockPath: lockPath,
+      });
+      cleanupTargets.push({ dispose: async () => await runtime.close() });
+
+      const handler = createRpcHandler(runtime);
+      const request: JsonRpcRequest = {
+        jsonrpc: "2.0",
+        id: 201,
+        method: "tools/call",
+        params: {
+          name: "files_search",
+          arguments: {
+            query: "hello",
+          },
+        },
+      };
+
+      const response = ensureResponse(await handler(request));
+      expect(response.statusCode).toBe(200);
+
+      const payload = response.response as JsonRpcSuccess;
+      const result = payload.result as Record<string, unknown>;
+
+      // MCP 2025-06-18: structuredContent フィールドが含まれることを検証
+      expect(result).toHaveProperty("content");
+      expect(result).toHaveProperty("structuredContent");
+      expect(result).toHaveProperty("isError");
+      expect(result.isError).toBe(false);
+
+      // structuredContent と content の整合性を検証
+      const content = result.content as Array<{ type: string; text: string }>;
+      const firstContent = content[0];
+      if (!firstContent) throw new Error("Content array is empty");
+
+      const contentParsed = JSON.parse(firstContent.text);
+      expect(result.structuredContent).toEqual(contentParsed);
+    });
+
+    it("tools/call エラー時は structuredContent を含まない", async () => {
+      const repo = await createTempRepo({
+        "src/app.ts": "export const app = () => 1;\n",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-mcp-structured-error-"));
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      const dbPath = join(dbDir, "index.duckdb");
+      const lockPath = join(dbDir, "security.lock");
+      const { hash } = loadSecurityConfig();
+      updateSecurityLock(hash, lockPath);
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const runtime = await createServerRuntime({
+        repoRoot: repo.path,
+        databasePath: dbPath,
+        securityLockPath: lockPath,
+      });
+      cleanupTargets.push({ dispose: async () => await runtime.close() });
+
+      const handler = createRpcHandler(runtime);
+      const request: JsonRpcRequest = {
+        jsonrpc: "2.0",
+        id: 202,
+        method: "tools/call",
+        params: {
+          name: "unknown_tool",
+          arguments: {},
+        },
+      };
+
+      const response = ensureResponse(await handler(request));
+      expect(response.statusCode).toBe(200);
+
+      const payload = response.response as JsonRpcSuccess;
+      const result = payload.result as Record<string, unknown>;
+
+      // エラー時はisError=trueでstructuredContentは含まれない
+      expect(result.isError).toBe(true);
+      expect(result).toHaveProperty("content");
+      expect(result.structuredContent).toBeUndefined();
+    });
+
+    it("context_bundle の structuredContent が正しい構造を持つ", async () => {
+      const repo = await createTempRepo({
+        "src/auth.ts": "export function login() { return true; }\n",
+        "src/app.ts": "import { login } from './auth';\nexport const app = login;\n",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-mcp-bundle-structured-"));
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      const dbPath = join(dbDir, "index.duckdb");
+      const lockPath = join(dbDir, "security.lock");
+      const { hash } = loadSecurityConfig();
+      updateSecurityLock(hash, lockPath);
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const runtime = await createServerRuntime({
+        repoRoot: repo.path,
+        databasePath: dbPath,
+        securityLockPath: lockPath,
+      });
+      cleanupTargets.push({ dispose: async () => await runtime.close() });
+
+      const handler = createRpcHandler(runtime);
+      const request: JsonRpcRequest = {
+        jsonrpc: "2.0",
+        id: 203,
+        method: "tools/call",
+        params: {
+          name: "context_bundle",
+          arguments: {
+            goal: "login authentication",
+            limit: 5,
+          },
+        },
+      };
+
+      const response = ensureResponse(await handler(request));
+      expect(response.statusCode).toBe(200);
+
+      const payload = response.response as JsonRpcSuccess;
+      const result = payload.result as Record<string, unknown>;
+
+      expect(result.structuredContent).toBeDefined();
+      const structured = result.structuredContent as Record<string, unknown>;
+
+      // context_bundle の構造を検証
+      expect(structured).toHaveProperty("context");
+      expect(Array.isArray(structured.context)).toBe(true);
+
+      const context = structured.context as Array<Record<string, unknown>>;
+      if (context.length > 0) {
+        const firstItem = context[0];
+        expect(firstItem).toHaveProperty("path");
+        expect(firstItem).toHaveProperty("range");
+        expect(firstItem).toHaveProperty("why");
+        expect(firstItem).toHaveProperty("score");
+        expect(Array.isArray(firstItem?.range)).toBe(true);
+        expect(Array.isArray(firstItem?.why)).toBe(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- MCP 2025-06-18仕様のStructured Output (`outputSchema`) に対応
- 全6つのMCPツールにJSON Schema出力スキーマを追加
- MCP仕様準拠のテストを追加

## 変更内容
- `src/server/output-schemas.ts`: 各ツールの出力スキーマ定義を追加
- `src/server/rpc.ts`: `tools/list`レスポンスに`outputSchema`を含めるよう修正
- `tests/server/mcp-standard.spec.ts`: MCP仕様準拠の検証テストを追加

## Test plan
- [x] `pnpm run test` - 全テストが通ることを確認
- [x] `pnpm run check` - lint & テストが通ることを確認

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)