### PR TITLE
fix: MCP Promptsを日本語から英語に翻訳

### DIFF
--- a/src/server/prompts.ts
+++ b/src/server/prompts.ts
@@ -83,56 +83,56 @@ interface PromptsConfig {
 export const PRESET_PROMPTS: PromptDescriptor[] = [
   {
     name: "debug-error",
-    description: "エラーメッセージから関連コードを検索",
+    description: "Search for related code from an error message",
     arguments: [
       {
         name: "error_message",
         required: true,
-        description: "エラーメッセージ",
+        description: "Error message",
       },
     ],
   },
   {
     name: "find-tests",
-    description: "指定ファイルのテストを検索",
+    description: "Search for tests for the specified file",
     arguments: [
       {
         name: "file_path",
         required: true,
-        description: "ファイルパス",
+        description: "File path",
       },
     ],
   },
   {
     name: "explain-function",
-    description: "関数の実装と使用箇所を検索",
+    description: "Search for function implementation and usage locations",
     arguments: [
       {
         name: "function_name",
         required: true,
-        description: "関数名",
+        description: "Function name",
       },
     ],
   },
   {
     name: "find-implementations",
-    description: "インターフェースや型の実装を検索",
+    description: "Search for implementations of an interface or type",
     arguments: [
       {
         name: "type_name",
         required: true,
-        description: "型名",
+        description: "Type name",
       },
     ],
   },
   {
     name: "trace-dependency",
-    description: "ファイルの依存関係をトレース",
+    description: "Trace file dependencies",
     arguments: [
       {
         name: "file_path",
         required: true,
-        description: "起点ファイルパス",
+        description: "Starting file path",
       },
       {
         name: "direction",
@@ -153,97 +153,97 @@ export const PRESET_PROMPTS: PromptDescriptor[] = [
 const PRESET_TEMPLATES: Record<string, (args: Record<string, string>) => string> = {
   "debug-error": (args) => {
     const errorMessage = args.error_message ?? "";
-    return `以下のエラーメッセージに関連するコードを検索してください。
+    return `Please search for code related to the following error message.
 
-## エラーメッセージ
+## Error Message
 \`\`\`
 ${errorMessage}
 \`\`\`
 
-## 検索手順
-1. \`context_bundle\` を使用してエラーメッセージ内のキーワード（関数名、ファイル名、クラス名等）で検索
-2. 関連するスタックトレース情報があれば、該当ファイルを \`snippets_get\` で確認
-3. エラーの原因となりそうなコードを特定
+## Search Steps
+1. Use \`context_bundle\` to search for keywords in the error message (function names, file names, class names, etc.)
+2. If there is related stack trace information, check the relevant files with \`snippets_get\`
+3. Identify code that may be causing the error
 
-## 期待する出力
-- エラーの原因箇所の特定
-- 修正案の提示`;
+## Expected Output
+- Identification of the error source
+- Suggested fixes`;
   },
 
   "find-tests": (args) => {
     const filePath = args.file_path ?? "";
-    return `以下のファイルに対応するテストファイルを検索してください。
+    return `Please search for test files corresponding to the following file.
 
-## 対象ファイル
+## Target File
 \`${filePath}\`
 
-## 検索手順
-1. \`files_search\` を使用して対象ファイル名に基づくテストファイルを検索
-   - 例: \`foo.ts\` → \`foo.spec.ts\`, \`foo.test.ts\`, \`__tests__/foo.ts\`
-2. テストファイルが見つかったら \`snippets_get\` で内容を確認
-3. \`deps_closure\` で対象ファイルの依存関係も確認し、関連テストを特定
+## Search Steps
+1. Use \`files_search\` to search for test files based on the target file name
+   - Example: \`foo.ts\` → \`foo.spec.ts\`, \`foo.test.ts\`, \`__tests__/foo.ts\`
+2. Once test files are found, check their contents with \`snippets_get\`
+3. Also check the target file's dependencies with \`deps_closure\` to identify related tests
 
-## 期待する出力
-- テストファイルのパス一覧
-- テストカバレッジの概要（テストされている関数/メソッド）`;
+## Expected Output
+- List of test file paths
+- Test coverage overview (functions/methods being tested)`;
   },
 
   "explain-function": (args) => {
     const functionName = args.function_name ?? "";
-    return `以下の関数の実装と使用箇所を検索して説明してください。
+    return `Please search for and explain the implementation and usage locations of the following function.
 
-## 関数名
+## Function Name
 \`${functionName}\`
 
-## 検索手順
-1. \`context_bundle\` を使用して関数定義を検索
-2. \`snippets_get\` で関数の完全な実装を取得
-3. \`files_search\` または \`deps_closure\` (direction: inbound) で使用箇所を特定
+## Search Steps
+1. Use \`context_bundle\` to search for the function definition
+2. Get the complete implementation with \`snippets_get\`
+3. Identify usage locations with \`files_search\` or \`deps_closure\` (direction: inbound)
 
-## 期待する出力
-- 関数のシグネチャと実装の説明
-- 主要な使用箇所
-- 依存関係（呼び出している他の関数）`;
+## Expected Output
+- Explanation of the function signature and implementation
+- Primary usage locations
+- Dependencies (other functions being called)`;
   },
 
   "find-implementations": (args) => {
     const typeName = args.type_name ?? "";
-    return `以下のインターフェース/型の実装を検索してください。
+    return `Please search for implementations of the following interface/type.
 
-## 型名
+## Type Name
 \`${typeName}\`
 
-## 検索手順
-1. \`context_bundle\` を使用して型定義を検索
-2. \`files_search\` で "implements ${typeName}" や "extends ${typeName}" を検索
-3. 各実装クラス/オブジェクトの概要を \`snippets_get\` で確認
+## Search Steps
+1. Use \`context_bundle\` to search for the type definition
+2. Search for "implements ${typeName}" or "extends ${typeName}" with \`files_search\`
+3. Check an overview of each implementing class/object with \`snippets_get\`
 
-## 期待する出力
-- 型定義の場所と内容
-- 実装一覧（クラス名、ファイルパス）
-- 各実装の特徴や違い`;
+## Expected Output
+- Location and content of the type definition
+- List of implementations (class names, file paths)
+- Features and differences of each implementation`;
   },
 
   "trace-dependency": (args) => {
     const filePath = args.file_path ?? "";
     const direction = args.direction ?? "both";
-    return `以下のファイルの依存関係をトレースしてください。
+    return `Please trace the dependencies of the following file.
 
-## 起点ファイル
+## Starting File
 \`${filePath}\`
 
-## 方向
-${direction === "both" ? "双方向（inbound + outbound）" : direction}
+## Direction
+${direction === "both" ? "Bidirectional (inbound + outbound)" : direction}
 
-## 検索手順
-1. \`deps_closure\` を使用して依存関係を取得
-   ${direction === "both" ? "- direction: outbound（このファイルが使用するモジュール）\n   - direction: inbound（このファイルを使用するモジュール）" : `- direction: ${direction}`}
-2. 重要な依存関係について \`snippets_get\` で詳細を確認
+## Search Steps
+1. Use \`deps_closure\` to get dependencies
+   ${direction === "both" ? "- direction: outbound (modules this file uses)\n   - direction: inbound (modules that use this file)" : `- direction: ${direction}`}
+2. Check details of important dependencies with \`snippets_get\`
 
-## 期待する出力
-- 依存グラフの概要
-- 主要な依存関係の説明
-- 循環依存の有無`;
+## Expected Output
+- Overview of the dependency graph
+- Explanation of major dependencies
+- Presence of circular dependencies`;
   },
 };
 

--- a/tests/server/prompts.spec.ts
+++ b/tests/server/prompts.spec.ts
@@ -39,7 +39,7 @@ describe("MCP Prompts", () => {
     it("should include debug-error prompt", () => {
       const prompt = PRESET_PROMPTS.find((p) => p.name === "debug-error");
       expect(prompt).toBeDefined();
-      expect(prompt?.description).toBe("エラーメッセージから関連コードを検索");
+      expect(prompt?.description).toBe("Search for related code from an error message");
       expect(prompt?.arguments).toHaveLength(1);
       expect(prompt?.arguments?.[0]?.name).toBe("error_message");
       expect(prompt?.arguments?.[0]?.required).toBe(true);
@@ -218,7 +218,7 @@ describe("MCP Prompts", () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result?.description).toBe("エラーメッセージから関連コードを検索");
+      expect(result?.description).toBe("Search for related code from an error message");
       expect(result?.messages).toHaveLength(1);
       expect(result?.messages[0]?.role).toBe("user");
       expect(result?.messages[0]?.content.type).toBe("text");


### PR DESCRIPTION
## 概要

MCP Promptsのプリセット定義が日本語で記述されていたため、英語に翻訳しました。

## 変更内容

### `src/server/prompts.ts`

- **PRESET_PROMPTS**: description を英語に翻訳
  - `エラーメッセージから関連コードを検索` → `Search for related code from an error message`
  - `指定ファイルのテストを検索` → `Search for tests for the specified file`
  - `関数の実装と使用箇所を検索` → `Search for function implementation and usage locations`
  - `インターフェースや型の実装を検索` → `Search for implementations of an interface or type`
  - `ファイルの依存関係をトレース` → `Trace file dependencies`
  - 引数の description も英語化

- **PRESET_TEMPLATES**: テンプレート文字列を英語に翻訳
  - 全5つのプリセットテンプレートの本文を英語化

### `tests/server/prompts.spec.ts`

- テストのアサーション値を英語に更新

## テスト結果

- `prompts.spec.ts`: 17テスト全てパス ✅
- `mcp-standard.spec.ts`: 24テスト全てパス ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)