### PR TITLE
fix: files_searchのpath_prefixフィルタを正規化 (Issue #162)

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -3329,8 +3329,11 @@ export async function filesSearch(
     hasTextQuery = cleanedQuery.length > 0;
   }
 
+  // Normalize path_prefix using shared utility for consistency with contextBundle
   const pathPrefix =
-    params.path_prefix && params.path_prefix.length > 0 ? params.path_prefix : undefined;
+    params.path_prefix && params.path_prefix.length > 0
+      ? normalizePathPrefix(params.path_prefix) || undefined
+      : undefined;
 
   const metadataValueSeed = metadataFilters
     .flatMap((filter) => filter.values)
@@ -3370,9 +3373,9 @@ export async function filesSearch(
         conditions.push("COALESCE(f.ext, '') = ?");
         values.push(params.ext);
       }
-      if (params.path_prefix) {
+      if (pathPrefix) {
         conditions.push("f.path LIKE ?");
-        values.push(`${params.path_prefix}%`);
+        values.push(`${pathPrefix}%`);
       }
       for (const clause of metadataClauses) {
         conditions.push(clause.sql);
@@ -3417,9 +3420,9 @@ export async function filesSearch(
         conditions.push("COALESCE(f.ext, '') = ?");
         values.push(params.ext);
       }
-      if (params.path_prefix) {
+      if (pathPrefix) {
         conditions.push("f.path LIKE ?");
-        values.push(`${params.path_prefix}%`);
+        values.push(`${pathPrefix}%`);
       }
       for (const clause of metadataClauses) {
         conditions.push(clause.sql);

--- a/src/server/rpc.ts
+++ b/src/server/rpc.ts
@@ -506,12 +506,16 @@ function parseFilesSearchParams(input: unknown): FilesSearchParams {
   if (typeof record.lang === "string") params.lang = record.lang;
   if (typeof record.ext === "string") params.ext = record.ext;
 
-  // Validate path_prefix to prevent path traversal attacks
+  // Validate and normalize path_prefix to prevent path traversal attacks
   if (typeof record.path_prefix === "string") {
     if (record.path_prefix.includes("..")) {
       throw new Error("path_prefix cannot contain '..' (path traversal not allowed)");
     }
-    params.path_prefix = record.path_prefix;
+    // Normalize: convert backslashes, remove leading slashes (consistent with parseContextBundleParams)
+    const normalizedPrefix = path.posix
+      .normalize(record.path_prefix.replace(/\\/g, "/"))
+      .replace(/^\/+/, "");
+    params.path_prefix = normalizedPrefix;
   }
 
   // Validate limit is within acceptable range

--- a/tests/server/files.search.spec.ts
+++ b/tests/server/files.search.spec.ts
@@ -677,5 +677,162 @@ category: dev
       expect(results.length).toBe(1);
       expect(results[0]!.path).toBe("docs/api/guide.md");
     });
+
+    it("normalizes path_prefix with leading slashes", async () => {
+      const repo = await createTempRepo({
+        "src/server/handler.ts": "export function handler() {}",
+        "src/client/app.ts": "const app = {};",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-path-leading-"));
+      const dbPath = join(dbDir, "index.duckdb");
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const db = await DuckDBClient.connect({ databasePath: dbPath });
+      cleanupTargets.push({ dispose: async () => await db.close() });
+
+      const repoId = await resolveRepoId(db, repo.path);
+      const tableAvailability = await checkTableAvailability(db);
+
+      const context: ServerContext = {
+        db,
+        repoId,
+        services: createServerServices(db),
+        tableAvailability,
+        warningManager: new WarningManager(),
+      };
+
+      // path_prefix with leading slash should be normalized
+      const results = await filesSearch(context, {
+        query: "handler",
+        path_prefix: "/src/server/",
+      });
+
+      expect(results.length).toBe(1);
+      expect(results[0]!.path).toBe("src/server/handler.ts");
+    });
+
+    it("normalizes path_prefix with backslashes", async () => {
+      const repo = await createTempRepo({
+        "src/server/handler.ts": "export function handler() {}",
+        "src/client/app.ts": "const app = {};",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-path-backslash-"));
+      const dbPath = join(dbDir, "index.duckdb");
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const db = await DuckDBClient.connect({ databasePath: dbPath });
+      cleanupTargets.push({ dispose: async () => await db.close() });
+
+      const repoId = await resolveRepoId(db, repo.path);
+      const tableAvailability = await checkTableAvailability(db);
+
+      const context: ServerContext = {
+        db,
+        repoId,
+        services: createServerServices(db),
+        tableAvailability,
+        warningManager: new WarningManager(),
+      };
+
+      // path_prefix with backslashes should be normalized
+      const results = await filesSearch(context, {
+        query: "handler",
+        path_prefix: "src\\server\\",
+      });
+
+      expect(results.length).toBe(1);
+      expect(results[0]!.path).toBe("src/server/handler.ts");
+    });
+
+    it("normalizes path_prefix starting with ./", async () => {
+      const repo = await createTempRepo({
+        "src/server/handler.ts": "export function handler() {}",
+        "src/client/app.ts": "const app = {};",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-path-dotslash-"));
+      const dbPath = join(dbDir, "index.duckdb");
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const db = await DuckDBClient.connect({ databasePath: dbPath });
+      cleanupTargets.push({ dispose: async () => await db.close() });
+
+      const repoId = await resolveRepoId(db, repo.path);
+      const tableAvailability = await checkTableAvailability(db);
+
+      const context: ServerContext = {
+        db,
+        repoId,
+        services: createServerServices(db),
+        tableAvailability,
+        warningManager: new WarningManager(),
+      };
+
+      // path_prefix starting with ./ should be normalized
+      const results = await filesSearch(context, {
+        query: "handler",
+        path_prefix: "./src/server/",
+      });
+
+      expect(results.length).toBe(1);
+      expect(results[0]!.path).toBe("src/server/handler.ts");
+    });
+
+    it("handles path_prefix that normalizes to empty string", async () => {
+      const repo = await createTempRepo({
+        "src/server/handler.ts": "export function handler() {}",
+        "src/client/app.ts": "const app = {};",
+      });
+      cleanupTargets.push({ dispose: repo.cleanup });
+
+      const dbDir = await mkdtemp(join(tmpdir(), "kiri-path-root-"));
+      const dbPath = join(dbDir, "index.duckdb");
+      cleanupTargets.push({
+        dispose: async () => await rm(dbDir, { recursive: true, force: true }),
+      });
+
+      await runIndexer({ repoRoot: repo.path, databasePath: dbPath, full: true });
+
+      const db = await DuckDBClient.connect({ databasePath: dbPath });
+      cleanupTargets.push({ dispose: async () => await db.close() });
+
+      const repoId = await resolveRepoId(db, repo.path);
+      const tableAvailability = await checkTableAvailability(db);
+
+      const context: ServerContext = {
+        db,
+        repoId,
+        services: createServerServices(db),
+        tableAvailability,
+        warningManager: new WarningManager(),
+      };
+
+      // path_prefix "/" normalizes to empty, so no path filter is applied
+      const results = await filesSearch(context, {
+        query: "handler",
+        path_prefix: "/",
+      });
+
+      // Should find handler in both files (no path filter)
+      expect(results.length).toBe(1);
+      expect(results[0]!.path).toBe("src/server/handler.ts");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `files_search`の`path_prefix`パラメータが正規化されておらず、先頭スラッシュ付きやバックスラッシュを含むパスを指定すると結果が空になる問題を修正
- `parseFilesSearchParams`と`filesSearch`で一貫した正規化処理を実装
- エッジケースのテストを追加

## 変更内容

- **rpc.ts**: `parseFilesSearchParams`で`path_prefix`を正規化
- **handlers.ts**: `filesSearch`で`normalizePathPrefix`関数を使用して一貫性を確保
- **files.search.spec.ts**: 4つの正規化テストケースを追加
  - 先頭スラッシュ（`/src/server/`）
  - バックスラッシュ（`src\server\`）
  - ドットスラッシュ（`./src/server/`）
  - ルートのみ（`/`）

## Test plan

- [x] 既存テスト全通過（874 passed, 7 skipped）
- [x] 新規テスト4件追加・通過
- [ ] 実環境でのMCP動作確認

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)