### PR TITLE
fix: gitignore仕様準拠のためignoreライブラリを導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "csv-parse": "^5.5.6",
     "fast-deep-equal": "^3.1.3",
     "gpt-tokenizer": "^3.2.0",
+    "ignore": "^7.0.5",
     "p-queue": "^9.0.0",
     "tree-sitter": "^0.22.0",
     "tree-sitter-java": "^0.23.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       gpt-tokenizer:
         specifier: ^3.2.0
         version: 3.2.0
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
       p-queue:
         specifier: ^9.0.0
         version: 9.0.0

--- a/src/indexer/pipeline/filters/denylist.ts
+++ b/src/indexer/pipeline/filters/denylist.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import ignore, { type Ignore } from "ignore";
+
 import { parseSimpleYaml } from "../../../shared/utils/simpleYaml.js";
 
 export interface DenylistConfig {
@@ -13,128 +15,9 @@ export interface DenylistFilter {
 }
 
 /**
- * Pattern classification type based on gitignore specification
- * - anywhere: no slash or trailing slash only or starts with ** - matches at any depth
- * - rooted: leading slash - matches only at root
- * - relative: intermediate slash - matches relative path
+ * .gitignore ファイルを読み込んでパターン配列を返す
+ * ファイルが存在しない場合は空配列を返す
  */
-type PatternType = "anywhere" | "rooted" | "relative";
-
-interface PatternClassification {
-  type: PatternType;
-  hasTrailingSlash: boolean;
-  normalizedPattern: string;
-}
-
-/**
- * Classify pattern based on gitignore specification
- *
- * Gitignore rules:
- * - No slash: matches at any depth (e.g., node_modules, *.log)
- * - Trailing slash only: matches directory at any depth (e.g., node_modules/)
- * - Leading slash: matches only at root (e.g., /node_modules/)
- * - Intermediate slash: matches relative path (e.g., src/generated/)
- *
- * @param pattern Glob pattern string
- * @returns Pattern classification result
- */
-function classifyPattern(pattern: string): PatternClassification {
-  const hasTrailingSlash = pattern.endsWith("/");
-  const trimmed = hasTrailingSlash ? pattern.slice(0, -1) : pattern;
-
-  // 先頭スラッシュあり: ルート相対
-  if (trimmed.startsWith("/")) {
-    return {
-      type: "rooted",
-      hasTrailingSlash,
-      normalizedPattern: trimmed.slice(1),
-    };
-  }
-
-  // Intermediate slash: relative path (gitignore spec)
-  // Patterns starting with **/ are treated as "anywhere" type
-  if (trimmed.includes("/") && !trimmed.startsWith("**/")) {
-    return {
-      type: "relative",
-      hasTrailingSlash,
-      normalizedPattern: trimmed,
-    };
-  }
-
-  // No slash, or starts with **/: matches at any depth
-  // For **/ prefix patterns, strip the **/ and let the "anywhere" prefix handle depth
-  const strippedPattern = trimmed.startsWith("**/") ? trimmed.slice(3) : trimmed;
-
-  return {
-    type: "anywhere",
-    hasTrailingSlash,
-    normalizedPattern: strippedPattern,
-  };
-}
-
-/**
- * Globパターンを正規表現に変換（ReDoS対策済み、gitignore仕様準拠）
- *
- * gitignore仕様:
- * - スラッシュなし/末尾スラッシュのみ: 任意の深さでマッチ
- *   例: node_modules/ → ルートでもサブディレクトリでもマッチ
- * - 先頭スラッシュあり: ルートのみマッチ
- *   例: /node_modules/ → ルート直下のみ
- * - 中間スラッシュあり: 相対パスとして解釈
- *   例: src/generated/ → src/generated/ にのみマッチ
- * - 末尾スラッシュ: ディレクトリのみマッチ（サブパスも含む）
- *
- * @param pattern Globパターン文字列
- * @returns コンパイル済み正規表現
- * @throws パターンが長すぎる、または複雑すぎる場合
- */
-function toRegex(pattern: string): RegExp {
-  // ReDoS対策: パターン長の制限
-  if (pattern.length > 500) {
-    throw new Error("Denylist pattern exceeds maximum length. Simplify the pattern.");
-  }
-
-  // 空パターンや過度に広いパターンを拒否
-  if (!pattern || pattern === "/" || pattern === "**" || pattern === "**/") {
-    throw new Error("Empty or overly broad denylist pattern. Provide a specific pattern.");
-  }
-
-  const { type, hasTrailingSlash, normalizedPattern } = classifyPattern(pattern);
-
-  // 正規表現用にエスケープ（**は後で処理するためプレースホルダに）
-  const escaped = normalizedPattern
-    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-    .replace(/\*\*/g, "::DOUBLESTAR::");
-
-  // Convert wildcards to regex
-  // IMPORTANT: Replace single * before doublestar placeholder
-  // to avoid .* having its * replaced with [^/]*
-  const withWildcards = escaped
-    .replace(/\*/g, "[^/]*")
-    .replace(/::DOUBLESTAR::/g, ".*")
-    .replace(/\?/g, "[^/]");
-
-  // ディレクトリの場合のサフィックス（サブパスにもマッチ）
-  const suffix = hasTrailingSlash ? "(?:/.*)?" : "";
-
-  // パターンタイプに応じてプレフィックス決定
-  // - anywhere: 任意の深さでマッチ（先頭または任意のディレクトリ境界から）
-  // - rooted/relative: ルートからのみマッチ
-  const prefix = type === "anywhere" ? "(?:^|.*/)" : "^";
-
-  const finalPattern = `${prefix}${withWildcards}${suffix}$`;
-
-  // ReDoS対策: 最終パターンの複雑度チェック（ネストした量指定子）
-  // [^/]* は bounded なので安全、.* のみを危険なパターンとしてカウント
-  // [^/]* を除去してから危険な量指定子をチェック
-  const withoutBounded = finalPattern.replace(/\[\^\/\]\*/g, "");
-  if (/(\.\*|\w\+|\{\d+,\}).*(\.\*|\w\+|\{\d+,\}).*(\.\*|\w\+|\{\d+,\})/.test(withoutBounded)) {
-    throw new Error("Denylist pattern is too complex. Use simpler glob patterns.");
-  }
-
-  return new RegExp(finalPattern);
-}
-
 function loadGitignore(repoRoot: string): string[] {
   try {
     const raw = readFileSync(resolve(repoRoot, ".gitignore"), "utf8");
@@ -148,8 +31,8 @@ function loadGitignore(repoRoot: string): string[] {
 }
 
 /**
- * denylist.ymlを読み込む
- * ファイルが存在しない場合は空のパターン配列を返す（.gitignoreのみで動作可能にする）
+ * denylist.yml を読み込む
+ * ファイルが存在しない場合は空のパターン配列を返す（.gitignore のみで動作可能にする）
  * ファイルが存在するが内容が無効な場合はエラーを投げる（設定ミスを検出可能にする）
  */
 export function loadDenylistConfig(configPath?: string): DenylistConfig {
@@ -178,18 +61,84 @@ export function loadDenylistConfig(configPath?: string): DenylistConfig {
   return { patterns };
 }
 
+// Validate patterns and throw error for overly broad or negation patterns.
+// Overly broad patterns match all files and are likely configuration mistakes.
+// Negation patterns are forbidden in denylist for security (denylist must always deny).
+function validatePatterns(patterns: string[]): void {
+  const overlyBroadPatterns = new Set(["", "**", "**/", "/"]);
+  for (const pattern of patterns) {
+    if (overlyBroadPatterns.has(pattern)) {
+      throw new Error(
+        `Overly broad denylist pattern: "${pattern}". ` +
+          "Use a more specific pattern or remove this entry."
+      );
+    }
+    // 否定パターンはdenylistでは禁止（セキュリティ上の理由）
+    if (pattern.startsWith("!")) {
+      throw new Error(
+        `Negation pattern in denylist: "${pattern}". ` +
+          "Denylist patterns must always deny; negation is not allowed."
+      );
+    }
+  }
+}
+
+/**
+ * denylist フィルターを作成する
+ *
+ * `ignore` ライブラリ (node-ignore) を使用して gitignore 互換のフィルタリングを行う。
+ * 注意: ルートの .gitignore のみ読み込む簡易ローダ実装。
+ *
+ * gitignore 互換の動作:
+ * - ディレクトリにマッチした場合、その配下のファイルも自動的に除外
+ * - 先頭スラッシュ（/node_modules）はルート直下のみマッチ
+ * - スラッシュなし（node_modules）は任意の深さでマッチ
+ *
+ * セキュリティ: denylist.yml のパターンは .gitignore より優先される（後から適用）。
+ * denylist.yml では否定パターン（!pattern）は禁止。
+ *
+ * @param repoRoot リポジトリルートの絶対パス
+ * @param configPath オプションの denylist.yml パス
+ * @returns DenylistFilter インターフェース
+ */
 export function createDenylistFilter(repoRoot: string, configPath?: string): DenylistFilter {
   const { patterns } = loadDenylistConfig(configPath);
+
+  // denylist.yml のパターンのみバリデーション（.gitignore はユーザーコントロール外の可能性があるため）
+  validatePatterns(patterns);
   const gitignorePatterns = loadGitignore(repoRoot);
-  const combined = Array.from(new Set([...patterns, ...gitignorePatterns]));
-  const regexList = combined.map(toRegex);
-  const diffEntries = gitignorePatterns.filter((pattern) => !patterns.includes(pattern));
+
+  // diff() 用: .gitignore にあって denylist.yml にないパターン
+  const patternSet = new Set(patterns);
+  const diffEntries = gitignorePatterns.filter((pattern) => !patternSet.has(pattern));
+
+  // ignore インスタンスを作成
+  // 重要: gitignore を先に追加し、denylist を後に追加することで denylist が優先される
+  // （ignore ライブラリは「後勝ち」セマンティクス）
+  const ig: Ignore = ignore().add(gitignorePatterns).add(patterns);
 
   return {
+    /**
+     * 指定されたパスが除外対象かどうかを判定
+     * @param path リポジトリルートからの相対パス
+     * @returns 除外対象の場合 true
+     */
     isDenied(path: string) {
+      // ignore ライブラリは先頭スラッシュなしのパスを期待する
       const normalized = path.startsWith("/") ? path.slice(1) : path;
-      return regexList.some((regex) => regex.test(normalized));
+
+      // 空パスはルートディレクトリ自体を表すので除外しない
+      if (normalized === "") {
+        return false;
+      }
+
+      return ig.ignores(normalized);
     },
+
+    /**
+     * .gitignore に含まれていて denylist.yml に含まれていないパターンを返す
+     * デバッグや差分確認用
+     */
     diff() {
       return diffEntries;
     },

--- a/tests/indexer/denylist.spec.ts
+++ b/tests/indexer/denylist.spec.ts
@@ -343,19 +343,42 @@ describe("エッジケース", () => {
     // ** パターンはエラー
     await writeFile(configPath, "patterns:\n  - '**'\n", "utf8");
     expect(() => createDenylistFilter(repo.path, configPath)).toThrow(
-      /Empty or overly broad denylist pattern/
+      /Overly broad denylist pattern/
     );
 
     // **/ パターンはエラー
     await writeFile(configPath, "patterns:\n  - '**/'\n", "utf8");
     expect(() => createDenylistFilter(repo.path, configPath)).toThrow(
-      /Empty or overly broad denylist pattern/
+      /Overly broad denylist pattern/
     );
 
     // / のみはエラー
     await writeFile(configPath, "patterns:\n  - '/'\n", "utf8");
     expect(() => createDenylistFilter(repo.path, configPath)).toThrow(
-      /Empty or overly broad denylist pattern/
+      /Overly broad denylist pattern/
+    );
+
+    await repo.cleanup();
+  });
+
+  it("throws for negation patterns in denylist (security)", async () => {
+    // 否定パターンはセキュリティ上の理由でdenylistでは禁止
+    const repo = await createTempRepo({
+      "src/index.ts": "console.log('ok');\n",
+    });
+
+    const configPath = join(repo.path, "denylist.yml");
+
+    // !pattern 形式はエラー
+    await writeFile(configPath, "patterns:\n  - '!important.txt'\n", "utf8");
+    expect(() => createDenylistFilter(repo.path, configPath)).toThrow(
+      /Negation pattern in denylist/
+    );
+
+    // !dir/ 形式もエラー
+    await writeFile(configPath, "patterns:\n  - '!keep/'\n", "utf8");
+    expect(() => createDenylistFilter(repo.path, configPath)).toThrow(
+      /Negation pattern in denylist/
     );
 
     await repo.cleanup();


### PR DESCRIPTION
## 概要
カスタム正規表現によるgitignoreパースを`ignore`（node-ignore）ライブラリに置き換え、gitignore仕様に完全準拠させる。

## 背景・課題
- ネストされた`node_modules`（例: `external/node_modules`）が除外されず、ファイル監視が41万件を超過
- カスタム実装ではgitignoreのディレクトリマッチ仕様を正しく処理できていなかった

## 変更内容
- **ignoreライブラリ採用**: gitignore仕様 2.22.1 完全準拠
  - ディレクトリマッチ（`node_modules/`が任意の深さでマッチ）
  - ダブルスターパターン（`**/temp`）
  - ルート相対（`/node_modules/`）と相対パス（`src/generated/`）

- **セキュリティ強化**:
  - denylist.ymlの否定パターン（`!pattern`）を禁止
  - denylist.ymlパターンを`.gitignore`より優先（後勝ちセマンティクス）
  - 過度に広いパターン（`**`, `**/`, `/`）を検証

- **コード削減**: 100行超のカスタム正規表現変換ロジックを削除

## テスト
- 17件のテストがパス（否定パターン検証テストを新規追加）
- gitignore仕様の主要パターンをカバー

## Test plan
- [x] `pnpm exec vitest run tests/indexer/denylist.spec.ts` - 17/17 パス
- [ ] 実際のリポジトリで`kiri`コマンドを実行し、ネストされたnode_modulesが除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)