### PR TITLE
fix: DaemonLifecycleにstale lock検出機能を追加

### DIFF
--- a/src/client/start-daemon.ts
+++ b/src/client/start-daemon.ts
@@ -13,38 +13,6 @@ import { fileURLToPath } from "url";
 import { getSocketPath } from "../shared/utils/socket.js";
 
 /**
- * ゾンビソケット・PIDファイルをクリーンアップ
- *
- * デーモンプロセスが異常終了した場合に残留するファイルを削除する。
- * - PIDファイル
- * - ソケットファイル（Unix系のみ）
- * - ロックファイル
- * - スタートアップロックファイル
- *
- * @param databasePath - データベースパス
- * @param socketPath - ソケットパス
- */
-async function cleanupStaleFiles(databasePath: string, socketPath: string): Promise<void> {
-  const pidFilePath = `${databasePath}.daemon.pid`;
-  const lockFilePath = `${socketPath}.lock`;
-  const startupLockPath = `${databasePath}.daemon.starting`;
-
-  const filesToClean = [pidFilePath, socketPath, lockFilePath, startupLockPath];
-
-  for (const filePath of filesToClean) {
-    try {
-      await fs.unlink(filePath);
-      console.error(`[StartDaemon] Cleaned up stale file: ${filePath}`);
-    } catch (err) {
-      // ファイルが存在しない場合は無視
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        console.error(`[StartDaemon] Failed to cleanup ${filePath}: ${(err as Error).message}`);
-      }
-    }
-  }
-}
-
-/**
  * デーモン起動オプション
  */
 export interface StartDaemonOptions {
@@ -84,9 +52,9 @@ export async function isDaemonRunning(
       process.kill(pid, 0); // シグナル0は存在チェック
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_err) {
-      // プロセスが存在しない場合、PIDファイルは古い → クリーンアップ実行
-      console.error("[StartDaemon] Stale PID file detected (process not running). Cleaning up...");
-      await cleanupStaleFiles(databasePath, socketPath);
+      // プロセスが存在しない場合、PIDファイルは古い
+      // Note: クリーンアップは意図的に行わない（デーモン起動中の競合を防ぐため）
+      console.error("[StartDaemon] Stale PID file detected");
       return false;
     }
 
@@ -144,47 +112,14 @@ export async function isDaemonRunning(
 
       return healthCheck;
     } catch (err) {
-      // ソケット接続失敗またはヘルスチェック失敗
-      // プロセスは存在するがソケットをリッスンしていない = ゾンビ状態
+      // ソケット接続失敗またはヘルスチェック失敗（起動中の可能性もあるため、クリーンアップは行わない）
       console.error(
         `[StartDaemon] Daemon health check failed: ${err instanceof Error ? err.message : String(err)}`
       );
-      console.error("[StartDaemon] Daemon is in zombie state. Stopping and cleaning up...");
-
-      // ゾンビプロセスを停止
-      try {
-        const pidStr = await fs.readFile(pidFilePath, "utf-8");
-        const zombiePid = parseInt(pidStr.trim(), 10);
-        process.kill(zombiePid, "SIGTERM");
-        // グレースフル停止を最大2秒待機
-        for (let i = 0; i < 20; i++) {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          try {
-            process.kill(zombiePid, 0);
-          } catch {
-            // プロセスが終了した
-            break;
-          }
-        }
-        // まだ生きている場合は強制終了
-        try {
-          process.kill(zombiePid, 0);
-          process.kill(zombiePid, "SIGKILL");
-        } catch {
-          // 既に終了済み
-        }
-      } catch {
-        // PIDファイル読み取りエラーは無視
-      }
-
-      await cleanupStaleFiles(databasePath, socketPath);
       return false;
     }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      // PIDファイルが存在しない場合でも、ソケットファイルやロックファイルが残っている可能性がある
-      // 念のためクリーンアップを実行
-      await cleanupStaleFiles(databasePath, socketPath);
       return false;
     }
     throw err;

--- a/tests/client/start-daemon.spec.ts
+++ b/tests/client/start-daemon.spec.ts
@@ -35,83 +35,63 @@ describe("Daemon Starter", () => {
       expect(running).toBe(false);
     });
 
-    it("returns false and cleans up when PID file contains stale PID", async () => {
+    it("returns false when PID file contains stale PID", async () => {
       const pidFilePath = `${databasePath}.daemon.pid`;
-      const socketPath = `${databasePath}.sock`;
-      const lockFilePath = `${socketPath}.lock`;
 
-      // 存在しないPIDとゾンビファイルを作成
+      // 存在しないPIDを書き込む
       const nonExistentPid = 999999;
       await fs.writeFile(pidFilePath, String(nonExistentPid), "utf-8");
-      await fs.writeFile(socketPath, "", "utf-8");
-      await fs.writeFile(lockFilePath, "", "utf-8");
 
       const running = await isDaemonRunning(databasePath);
       expect(running).toBe(false);
 
-      // ゾンビファイルがクリーンアップされていることを確認
-      await expect(fs.access(pidFilePath)).rejects.toThrow();
-      await expect(fs.access(socketPath)).rejects.toThrow();
-      await expect(fs.access(lockFilePath)).rejects.toThrow();
+      // PIDファイルは残っていることを確認（積極的なクリーンアップは行わない）
+      await fs.access(pidFilePath); // Should not throw
     });
 
-    it("returns false and attempts cleanup when daemon health check fails", async () => {
+    it("returns false when daemon process exists but socket is not responsive", async () => {
       const pidFilePath = `${databasePath}.daemon.pid`;
-      const socketPath = `${databasePath}.sock`;
-      const lockFilePath = `${socketPath}.lock`;
 
-      // 存在しないPIDを書き込む（実プロセスを使うとテストが不安定になる）
-      // ヘルスチェック失敗時の動作を確認
-      const nonExistentPid = 999998;
-      await fs.writeFile(pidFilePath, String(nonExistentPid), "utf-8");
-      await fs.writeFile(socketPath, "", "utf-8");
-      await fs.writeFile(lockFilePath, "", "utf-8");
+      // 現在のプロセスのPIDを書き込む（ソケットは存在しない）
+      await fs.writeFile(pidFilePath, String(process.pid), "utf-8");
 
       const running = await isDaemonRunning(databasePath);
       expect(running).toBe(false);
 
-      // ゾンビファイルがクリーンアップされていることを確認
-      await expect(fs.access(pidFilePath)).rejects.toThrow();
-      await expect(fs.access(socketPath)).rejects.toThrow();
-      await expect(fs.access(lockFilePath)).rejects.toThrow();
+      // PIDファイルは残っていることを確認（デーモン起動中の可能性があるため）
+      await fs.access(pidFilePath); // Should not throw
     });
 
-    it("cleans up all stale files including startup lock", async () => {
+    it("does not clean up stale files to avoid race conditions", async () => {
       const pidFilePath = `${databasePath}.daemon.pid`;
       const socketPath = `${databasePath}.sock`;
-      const lockFilePath = `${socketPath}.lock`;
+
+      // 存在しないPIDとソケットファイルを作成
+      await fs.writeFile(pidFilePath, "999999", "utf-8");
+      await fs.writeFile(socketPath, "", "utf-8"); // ダミーソケット
+
+      const running = await isDaemonRunning(databasePath);
+      expect(running).toBe(false);
+
+      // ファイルは残っていることを確認（デーモン自身がクリーンアップを担当）
+      await fs.access(pidFilePath); // Should not throw
+      await fs.access(socketPath); // Should not throw
+    });
+
+    it("preserves startup lock file to avoid interfering with daemon startup", async () => {
+      const pidFilePath = `${databasePath}.daemon.pid`;
       const startupLockPath = `${databasePath}.daemon.starting`;
 
-      // 存在しないPIDと全てのゾンビファイルを作成
-      await fs.writeFile(pidFilePath, "999997", "utf-8");
-      await fs.writeFile(socketPath, "", "utf-8");
-      await fs.writeFile(lockFilePath, "", "utf-8");
-      await fs.writeFile(startupLockPath, "999997", "utf-8");
+      // 存在しないPIDとスタートアップロックを作成
+      await fs.writeFile(pidFilePath, "999999", "utf-8");
+      await fs.writeFile(startupLockPath, "999999", "utf-8");
 
       const running = await isDaemonRunning(databasePath);
       expect(running).toBe(false);
 
-      // 全てのゾンビファイルがクリーンアップされていることを確認
-      await expect(fs.access(pidFilePath)).rejects.toThrow();
-      await expect(fs.access(socketPath)).rejects.toThrow();
-      await expect(fs.access(lockFilePath)).rejects.toThrow();
-      await expect(fs.access(startupLockPath)).rejects.toThrow();
-    });
-
-    it("cleans up stale files even when PID file does not exist", async () => {
-      const socketPath = `${databasePath}.sock`;
-      const lockFilePath = `${socketPath}.lock`;
-
-      // PIDファイルなしでソケットとロックファイルだけ存在する状態
-      await fs.writeFile(socketPath, "", "utf-8");
-      await fs.writeFile(lockFilePath, "", "utf-8");
-
-      const running = await isDaemonRunning(databasePath);
-      expect(running).toBe(false);
-
-      // ゾンビファイルがクリーンアップされていることを確認
-      await expect(fs.access(socketPath)).rejects.toThrow();
-      await expect(fs.access(lockFilePath)).rejects.toThrow();
+      // ファイルは残っていることを確認（起動中のデーモンを妨害しないため）
+      await fs.access(pidFilePath); // Should not throw
+      await fs.access(startupLockPath); // Should not throw
     });
   });
 


### PR DESCRIPTION
## 概要

デーモンプロセスが異常終了した場合に残る古いロックファイル（stale lock）を自動検出・クリーンアップする機能を追加しました。

## 変更内容

### `src/daemon/lifecycle.ts`

- **`isProcessRunning()`ヘルパー関数を追加**: PIDが有効（正の整数）かつプロセスが存在するかを安全にチェック
- **`acquireStartupLock()`にstale lock検出を実装**:
  - ロックファイルが存在する場合、所有プロセスが死んでいるかチェック
  - TOCTOU（Time-of-check-time-of-use）対策として、削除前にPIDを再検証
  - stale lockを検出した場合のみクリーンアップして再取得を試みる

### `tests/daemon/lifecycle.spec.ts`

- stale lock検出のテストを追加（3ケース）

## 設計判断

**daemon-side implementation**を採用しました。クライアント側（`start-daemon.ts`の`isDaemonRunning()`）でのクリーンアップは以下のリスクがあるため避けました：

1. **Command-Query Separation違反**: 「実行中かチェック」という純粋なクエリに副作用を持たせるのは危険
2. **競合状態**: 複数クライアントが同時にクリーンアップを試みる可能性
3. **起動中のデーモンへの干渉**: 起動処理中のデーモンのファイルを誤って削除するリスク

デーモン側でロック取得時にのみstale検出を行うことで、安全かつ確実なクリーンアップを実現しています。

## テスト

- すべてのテストがパス（24 tests）
- 新規テストケース3件を追加

## 関連

Issue #156で報告されたMCP接続問題の修正（#167）に関連する改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)