### PR TITLE
fix(server): detect io corruption for auto reindex

### DIFF
--- a/src/server/indexBootstrap.ts
+++ b/src/server/indexBootstrap.ts
@@ -41,7 +41,7 @@ function isCorruptDatabaseError(error: unknown): boolean {
   }
   const message = error.message ?? "";
   const normalized = message.toLowerCase();
-  const ioCorruptionHints =
+  const deserializeCorruption =
     normalized.includes("deserializedeletes") ||
     (normalized.includes("deserialize") &&
       (normalized.includes("corrupted file") ||
@@ -49,12 +49,11 @@ function isCorruptDatabaseError(error: unknown): boolean {
         normalized.includes("row group size")));
   return (
     normalized.includes("serialization error") ||
-    normalized.includes("failed to deserialize") ||
     normalized.includes("field id mismatch") ||
     normalized.includes("database file is not compatible") ||
     normalized.includes("file is not a database") ||
     (normalized.includes("catalog error") && normalized.includes("type")) ||
-    (normalized.includes("io error") && ioCorruptionHints)
+    (normalized.includes("io error") && deserializeCorruption)
   );
 }
 


### PR DESCRIPTION
## 目的
IO Error: DeserializeDeletes などの破損兆候を検知した際に、起動時の自動 full reindex が発火するようにする。

## 実装概要
- `isCorruptDatabaseError()` に IO エラーの破損ヒント語判定を追加し、より確度の高いケースのみ破損扱いに。

## 検証手順
- 手動: `isCorruptDatabaseError` の判定が期待どおりになることを確認（臨時スクリプトで実施）。
- 公式テストは未実行。

## 残課題
- 実DB破損時の起動フローで自動 reindex が発火するかの統合検証。