### PR TITLE
chore(mcp): clarify query language guidance

### DIFF
--- a/src/server/rpc.ts
+++ b/src/server/rpc.ts
@@ -214,6 +214,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
     name: "context_bundle",
     description:
       "Find relevant code for a goal. Returns ranked snippets with path, range, score. Use concrete keywords.\n" +
+      "Query language: code -> repository programming language identifiers/errors; docs -> English or project language.\n" +
       "Example: context_bundle({goal: 'pagination off-by-one bug src/catalog/products.ts'})",
     inputSchema: {
       type: "object",
@@ -294,6 +295,7 @@ const TOOL_DESCRIPTORS: ToolDescriptor[] = [
     name: "files_search",
     description:
       "Search files by keyword. Returns path, matchLine, score.\n" +
+      "Query language: code -> repository programming language identifiers/errors; docs -> English or project language.\n" +
       "Example: files_search({query: 'handleUserLogin', ext: '.ts'})",
     inputSchema: {
       type: "object",


### PR DESCRIPTION
## 目的
MCP ツール説明に検索言語の使い分けを明確化するため。

## 実装概要
- `context_bundle` / `files_search` の description に「コード検索はリポジトリのプログラミング言語、ドキュメントは英語またはプロジェクト言語」を追記。

## 検証手順
- 未実施（説明文のみの変更）

## 残課題
- なし
