### PR TITLE
docs(eval): ゴールデン評価のベースライン指標を記録

### DIFF
--- a/tests/eval/goldens/baseline.json
+++ b/tests/eval/goldens/baseline.json
@@ -1,94 +1,122 @@
 {
-  "version": "0.10.0",
-  "gitSha": "9e59843",
-  "date": "2025-11-17T01:56:59.937Z",
+  "version": "0.25.8",
+  "gitSha": "ef2fc09",
+  "date": "2025-12-30T07:00:00.000Z",
   "datasetVersion": "v2025-11-docs-plain",
-  "description": "Baseline measurement after metadata hint vs docmeta filter split (docs vs docs-plain comparison).",
+  "description": "Issue #186 baseline measurement - goldens基準線を固定（現状値記録）",
   "thresholds": {
     "minP10": 0.7,
     "minR5": 0.5,
     "maxTTFU": 1000,
     "minMetadataPassRate": 1,
     "minInboundPassRate": 1,
-    "description": "Target metrics from docs/overview.md: P@10 ≥ 0.7, TTFU ≤ 1.0s"
+    "description": "Target metrics from docs/overview.md: P@10 >= 0.7, TTFU <= 1.0s"
   },
   "overall": {
-    "precisionAtK": 0.2863636364,
-    "avgTTFU": 1.1470588235,
-    "totalQueries": 22,
-    "successfulQueries": 17,
-    "failedQueries": 5,
-    "avgTokensEstimate": 42461.7273,
-    "avgBaselineTokens": 457694.1176,
-    "avgTokenSavingsRatio": 0.8951621479,
-    "avgHintCoverage": 0.1411764706,
-    "metadataPassRate": 0.5,
-    "inboundPassRate": 0.5
+    "precisionAtK": 0.243,
+    "recallAt5": 0.597,
+    "avgTTFU": 7,
+    "totalQueries": 36,
+    "successfulQueries": 36,
+    "failedQueries": 0,
+    "avgTokensEstimate": 3976,
+    "avgBaselineTokens": 236857,
+    "avgTokenSavingsRatio": 0.967,
+    "avgHintCoverage": 0.056,
+    "metadataPassRate": 1.0,
+    "inboundPassRate": 1.0
   },
   "byCategory": {
     "editor": {
-      "precisionAtK": 0.2,
+      "precisionAtK": 0.35,
+      "recallAt5": 0.833,
       "avgTTFU": 0,
       "count": 2,
-      "avgTokenSavingsRatio": 0.9809868942,
-      "avgHintCoverage": 0.3,
+      "avgTokenSavingsRatio": 0.966,
+      "avgHintCoverage": 0.2,
       "metadataPassRate": null,
       "inboundPassRate": null
     },
     "api": {
-      "precisionAtK": 0.1333333333,
+      "precisionAtK": 0.2,
+      "recallAt5": 0.917,
       "avgTTFU": 0,
       "count": 3,
-      "avgTokenSavingsRatio": 0.8790261687,
-      "avgHintCoverage": 0.1666666667,
+      "avgTokenSavingsRatio": 0.988,
+      "avgHintCoverage": 0.133,
       "metadataPassRate": null,
       "inboundPassRate": null
     },
     "debug": {
       "precisionAtK": 0.15,
+      "recallAt5": 1.0,
       "avgTTFU": 0,
       "count": 2,
-      "avgTokenSavingsRatio": 0.8104621471,
+      "avgTokenSavingsRatio": 0.974,
       "avgHintCoverage": 0.15,
       "metadataPassRate": null,
       "inboundPassRate": null
     },
     "feature": {
-      "precisionAtK": 0.125,
+      "precisionAtK": 0.267,
+      "recallAt5": 0.482,
       "avgTTFU": 0,
-      "count": 4,
-      "avgTokenSavingsRatio": 0.9860883952,
-      "avgHintCoverage": 0.175,
+      "count": 6,
+      "avgTokenSavingsRatio": 0.985,
+      "avgHintCoverage": 0.083,
       "metadataPassRate": null,
       "inboundPassRate": null
     },
     "infra": {
-      "precisionAtK": 0.2,
+      "precisionAtK": 0.6,
+      "recallAt5": 1.0,
       "avgTTFU": 0,
       "count": 1,
-      "avgTokenSavingsRatio": 0.6274278364,
-      "avgHintCoverage": 0.3,
+      "avgTokenSavingsRatio": 0.96,
+      "avgHintCoverage": 0.4,
       "metadataPassRate": null,
       "inboundPassRate": null
     },
     "docs": {
-      "precisionAtK": 0.9,
-      "avgTTFU": 3.9,
-      "count": 5,
-      "avgTokenSavingsRatio": 0.8851997017,
-      "avgHintCoverage": 0,
-      "metadataPassRate": 1,
-      "inboundPassRate": 1
-    },
-    "docs-plain": {
-      "precisionAtK": 0,
+      "precisionAtK": 0.25,
+      "recallAt5": 0.567,
       "avgTTFU": 0,
       "count": 5,
-      "avgTokenSavingsRatio": null,
-      "avgHintCoverage": null,
-      "metadataPassRate": 0,
-      "inboundPassRate": 0
+      "avgTokenSavingsRatio": 0.973,
+      "avgHintCoverage": 0,
+      "metadataPassRate": 1.0,
+      "inboundPassRate": 1.0
+    },
+    "docs-plain": {
+      "precisionAtK": 0.3,
+      "recallAt5": 0.9,
+      "avgTTFU": 1,
+      "count": 5,
+      "avgTokenSavingsRatio": 0.882,
+      "avgHintCoverage": 0,
+      "metadataPassRate": 1.0,
+      "inboundPassRate": 1.0
+    },
+    "graph-test": {
+      "precisionAtK": 0.183,
+      "recallAt5": 0.319,
+      "avgTTFU": 19,
+      "count": 6,
+      "avgTokenSavingsRatio": 0.989,
+      "avgHintCoverage": 0,
+      "metadataPassRate": null,
+      "inboundPassRate": null
+    },
+    "graph-test-baseline": {
+      "precisionAtK": 0.183,
+      "recallAt5": 0.319,
+      "avgTTFU": 29,
+      "count": 6,
+      "avgTokenSavingsRatio": 0.988,
+      "avgHintCoverage": 0,
+      "metadataPassRate": null,
+      "inboundPassRate": null
     }
   },
-  "notes": "Metrics captured from pnpm run eval:golden on 2025-11-17 after metadata hint vs docmeta filter changes."
+  "notes": "Issue #186 baseline measurement on 2025-12-30. LLM再ランキングなし、1仮説/1パラメータ（測定のみ）、対象ドメイン非依存。"
 }

--- a/tests/eval/results/2025-12-30-baseline-v0.25.8.md
+++ b/tests/eval/results/2025-12-30-baseline-v0.25.8.md
@@ -1,0 +1,101 @@
+# KIRI Golden Set Baseline Measurement - 2025-12-30
+
+**Issue**: #186 - P0: goldens基準線を固定（現状値記録）
+
+## Overview
+
+このドキュメントは Issue #186 の要件に従い、goldens評価の基準線を固定するために実施した測定結果を記録したものです。
+
+## Measurement Details
+
+| Item                   | Value               |
+| ---------------------- | ------------------- |
+| **Date**               | 2025-12-30          |
+| **Version**            | 0.25.8              |
+| **Git SHA**            | ef2fc09             |
+| **Dataset Version**    | v2025-11-docs-plain |
+| **Schema Version**     | 1.0.0               |
+| **Total Queries**      | 36                  |
+| **Successful Queries** | 36                  |
+| **Failed Queries**     | 0                   |
+
+## Overall Metrics
+
+| Metric              | Value  | Threshold | Status       |
+| ------------------- | ------ | --------- | ------------ |
+| P@10                | 0.243  | >= 0.7    | Below target |
+| R@5                 | 0.597  | >= 0.5    | Pass         |
+| Avg TFFU            | 7ms    | <= 1000ms | Pass         |
+| Avg Token Savings   | 96.7%  | >= 40%    | Pass         |
+| Avg Hint Coverage   | 5.6%   | -         | -            |
+| Metadata Pass       | 100.0% | >= 100%   | Pass         |
+| Inbound Link Pass   | 100.0% | >= 100%   | Pass         |
+| Avg Bundle Tokens   | 3976   | -         | -            |
+| Avg Baseline Tokens | 236857 | -         | -            |
+| Max Startup         | 2047ms | -         | -            |
+
+## By Category
+
+| Category            | P@10  | R@5   | Avg TFFU | Avg Token Savings | Avg Hint Coverage | Metadata Pass | Inbound Pass | Count |
+| ------------------- | ----- | ----- | -------- | ----------------- | ----------------- | ------------- | ------------ | ----- |
+| editor              | 0.350 | 0.833 | 0ms      | 96.6%             | 20.0%             | N/A           | N/A          | 2     |
+| api                 | 0.200 | 0.917 | 0ms      | 98.8%             | 13.3%             | N/A           | N/A          | 3     |
+| debug               | 0.150 | 1.000 | 0ms      | 97.4%             | 15.0%             | N/A           | N/A          | 2     |
+| feature             | 0.267 | 0.482 | 0ms      | 98.5%             | 8.3%              | N/A           | N/A          | 6     |
+| infra               | 0.600 | 1.000 | 0ms      | 96.0%             | 40.0%             | N/A           | N/A          | 1     |
+| docs                | 0.250 | 0.567 | 0ms      | 97.3%             | 0.0%              | 100.0%        | 100.0%       | 5     |
+| docs-plain          | 0.300 | 0.900 | 1ms      | 88.2%             | 0.0%              | 100.0%        | 100.0%       | 5     |
+| graph-test          | 0.183 | 0.319 | 19ms     | 98.9%             | 0.0%              | N/A           | N/A          | 6     |
+| graph-test-baseline | 0.183 | 0.319 | 29ms     | 98.8%             | 0.0%              | N/A           | N/A          | 6     |
+
+## Category Comparison (docs vs docs-plain)
+
+| Baseline | Variant    | Delta P@10 | Delta Metadata Pass | Delta Inbound Pass |
+| -------- | ---------- | ---------- | ------------------- | ------------------ |
+| docs     | docs-plain | +0.050     | +0.000              | +0.000             |
+
+## Notes
+
+- LLM再ランキングなし
+- 1仮説/1パラメータ（測定のみ）
+- 対象ドメイン非依存
+
+### Observations
+
+1. **P@10 (0.243)**: 目標値 0.7 を大きく下回っている。これは現時点での検索精度の課題を示している。
+2. **R@5 (0.597)**: 目標値 0.5 を上回っており、関連結果が上位5件内に含まれる率は良好。
+3. **TFFU (7ms)**: 目標値 1000ms を大幅に下回っており、レスポンス速度は非常に良好。
+4. **Token Savings (96.7%)**: 目標値 40% を大幅に上回っており、トークン削減は非常に効果的。
+5. **Metadata/Inbound Pass (100%)**: メタデータとインバウンドリンクの処理は完全に動作。
+
+### Reproducibility
+
+このベースライン測定を再現するには：
+
+```bash
+# 1. リポジトリのインデックスを作成（既存の場合はスキップ可）
+pnpm exec tsx src/indexer/cli.ts --repo . --db var/index.duckdb --full
+
+# 2. セキュリティロックを作成（既存の場合はスキップ可）
+pnpm exec tsx src/client/cli.ts security verify --db var/index.duckdb --security-lock var/security.lock --write-lock
+
+# 3. 評価を実行
+KIRI_ALLOW_UNSAFE_PATHS=1 pnpm run eval:golden
+```
+
+### Prerequisites
+
+以下のリポジトリとインデックスが必要：
+
+| Repository | Path               | Index Path                            |
+| ---------- | ------------------ | ------------------------------------- |
+| kiri       | .                  | var/index.duckdb                      |
+| vscode     | external/vscode    | external/vscode/.kiri/index.duckdb    |
+| assay-kit  | external/assay-kit | external/assay-kit/.kiri/index.duckdb |
+| docs-plain | tmp/docs-plain     | tmp/docs-plain/.kiri/index.duckdb     |
+
+## Related
+
+- Parent Issue: #177
+- Documentation: tests/eval/goldens/README.md
+- Results location: var/eval/latest.json, var/eval/latest.md

--- a/tests/eval/results/README.md
+++ b/tests/eval/results/README.md
@@ -74,6 +74,7 @@ Add a new row to the "Results Summary" table below with:
 
 | Date       | Version | Git SHA | Dataset             | P@10  | Avg TFFU | Notes                                                                                      |
 | ---------- | ------- | ------- | ------------------- | ----- | -------- | ------------------------------------------------------------------------------------------ |
+| 2025-12-30 | 0.25.8  | ef2fc09 | v2025-11-docs-plain | 0.243 | 7ms      | Issue #186 baseline measurement; R@5=0.597, TokenSavings=96.7%, Metadata/Inbound Pass=100% |
 | 2025-11-17 | 0.10.0  | 9e59843 | v2025-11-docs-plain | 0.286 | 1ms      | Baseline after metadata hint/docmeta split; docs pass=100%, docs-plain intentionally fails |
 
 **Legend:**


### PR DESCRIPTION
## Summary

- v0.25.8時点でのゴールデン評価ベースラインを記録
- 再現性を確認済み（2回実行で同一結果）

## 測定結果

| 指標 | 値 | 目標 | 状態 |
|------|-----|------|------|
| **P@10** | 0.243 | >= 0.7 | ❌ 未達（改善課題） |
| **R@5** | 0.597 | >= 0.5 | ✅ 達成 |
| **TFFU** | 7ms | <= 1000ms | ✅ 達成 |
| **Token Savings** | 96.7% | >= 40% | ✅ 達成 |
| **Metadata Pass** | 100% | - | ✅ |
| **Inbound Link Pass** | 100% | - | ✅ |

## 成果物

- `tests/eval/results/2025-12-30-baseline-v0.25.8.md` - 詳細な測定結果と再現手順
- `tests/eval/goldens/baseline.json` - 更新されたベースライン
- `tests/eval/results/README.md` - サマリーテーブル更新

## Test plan

- [x] `pnpm run eval:golden` で再現性確認済み

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)