### PR TITLE
docs(tokenization): phrase-awareとhybridの動作説明を実装に合わせて修正

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,11 +58,11 @@ Control how KIRI tokenizes and matches compound terms:
 export KIRI_TOKENIZATION_STRATEGY=phrase-aware  # default
 ```
 
-| Strategy       | Behavior                                                                  | Best For                      |
-| -------------- | ------------------------------------------------------------------------- | ----------------------------- |
-| `phrase-aware` | Compound terms (kebab-case, snake_case) treated as phrases with 2× weight | Consistent naming conventions |
-| `legacy`       | Traditional word-by-word tokenization                                     | Backward compatibility        |
-| `hybrid`       | Both phrase and word-level matching                                       | Maximum flexibility           |
+| Strategy       | Behavior                                                                                                | Best For                  |
+| -------------- | ------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `phrase-aware` | Compound terms preserved + split keywords output (e.g., "page-agent" → ["page-agent", "page", "agent"]) | General use (default)     |
+| `legacy`       | Traditional word-by-word tokenization (compound terms not preserved)                                    | Backward compatibility    |
+| `hybrid`       | Same as phrase-aware in tokenizer.ts; handlers.ts separates phrases/keywords                            | ExtractedTerms separation |
 
 ## Scoring Profiles
 

--- a/docs/search-ranking.md
+++ b/docs/search-ranking.md
@@ -41,17 +41,20 @@ tokenization:
 
 ### 戦略の種類
 
-| 戦略                          | 説明                                       | 例: "page-agent" の処理           |
-| ----------------------------- | ------------------------------------------ | --------------------------------- |
-| **phrase-aware** (デフォルト) | ハイフン区切り用語を単一ユニットとして保持 | `["page-agent"]`                  |
-| **legacy**                    | ハイフンで分割（従来の動作）               | `["page", "agent"]`               |
-| **hybrid**                    | フレーズと分割キーワードの両方を出力       | `["page-agent", "page", "agent"]` |
+| 戦略                          | 説明                                                 | 例: "page-agent" の処理           |
+| ----------------------------- | ---------------------------------------------------- | --------------------------------- |
+| **phrase-aware** (デフォルト) | 複合用語を保持しつつ、分割キーワードも出力           | `["page-agent", "page", "agent"]` |
+| **legacy**                    | ハイフンで分割（従来の動作、複合用語は保持されない） | `["page", "agent"]`               |
+| **hybrid**                    | phrase-awareと同等（handlers.tsでの処理が異なる）    | `["page-agent", "page", "agent"]` |
+
+> **Note**: `tokenizeText()` 関数（src/shared/tokenizer.ts）では phrase-aware と hybrid は同一動作です。
+> handlers.ts の `extractKeywords()` でのみ hybrid は phrases と keywords を分離して管理します。
 
 ### 推奨設定
 
-- **一般的な使用**: `phrase-aware` (デフォルト) - 最も正確なマッチングを提供
-- **後方互換性が必要な場合**: `legacy` - 従来の動作を維持
-- **網羅的な検索**: `hybrid` - 最も広範なマッチングを提供（トークン数増加のトレードオフあり）
+- **一般的な使用**: `phrase-aware` (デフォルト) - 複合用語と分割キーワードの両方でマッチング
+- **後方互換性が必要な場合**: `legacy` - 従来の動作を維持（複合用語なし）
+- **handlers.ts での分離管理**: `hybrid` - ExtractedTerms 構造体で phrases/keywords を分離
 
 ## ストップワード設定
 

--- a/tests/shared/tokenizer.spec.ts
+++ b/tests/shared/tokenizer.spec.ts
@@ -32,4 +32,25 @@ describe("tokenizeText", () => {
     expect(tokens).toEqual(expect.arrayContaining(["foo", "bar", "baz"]));
     expect(tokens).not.toContain("foo-bar");
   });
+
+  // LAW-token-hybrid-consistency: hybrid戦略はphrase-awareと同一動作
+  // @see Issue #189
+  describe("hybrid strategy", () => {
+    it("outputs both compound terms and split keywords (same as phrase-aware)", () => {
+      const tokens = tokenizeText("page-agent handler", "hybrid");
+      expect(tokens).toEqual(expect.arrayContaining(["page-agent", "page", "agent", "handler"]));
+    });
+
+    it("handles snake_case same as phrase-aware", () => {
+      const tokens = tokenizeText("worker_pool", "hybrid");
+      expect(tokens).toEqual(expect.arrayContaining(["worker_pool", "worker", "pool"]));
+    });
+
+    it("produces identical output to phrase-aware", () => {
+      const input = "context-bundle ISO8601Parser";
+      const phraseAwareTokens = tokenizeText(input, "phrase-aware");
+      const hybridTokens = tokenizeText(input, "hybrid");
+      expect(hybridTokens).toEqual(phraseAwareTokens);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- docs/search-ranking.md: 戦略の説明を実装に合わせて修正
  - phrase-awareも両方出力（複合用語+分割キーワード）することを明記
  - tokenizer.tsとhandlers.tsの動作の違いをNoteで説明
- docs/configuration.md: 戦略テーブルを実装に合わせて修正
- tests/shared/tokenizer.spec.ts: hybrid戦略のテスト3件追加

## A/Bテスト結果
| 指標 | phrase-aware | hybrid | 差分 |
|------|-------------|--------|------|
| P@10 | 0.243 | 0.243 | ±0.0% |
| R@5 | 0.597 | 0.597 | ±0.0% |
| TFFU | 13ms | 15ms | +2ms |

tokenizer.tsで両戦略は同一動作のため、検索結果に差異なし。

## Test plan
- [x] `pnpm exec vitest run tests/shared/tokenizer.spec.ts` (8 tests pass)
- [x] golden評価でphrase-aware/hybrid比較実施

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)