### PR TITLE
refactor: unify path traversal detection logic

### DIFF
--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -8,6 +8,7 @@ import { parse as parseYAML } from "yaml";
 
 import { DuckDBClient } from "../shared/duckdb.js";
 import { generateEmbedding } from "../shared/embedding.js";
+import { isPathTraversal } from "../shared/fs/pathTraversal.js";
 import { acquireLock, releaseLock, LockfileError, getLockOwner } from "../shared/utils/lockfile.js";
 import {
   normalizeDbPath,
@@ -1512,7 +1513,8 @@ export function normalizePathForDenylist(filePath: string): string {
     normalized = normalized.slice(1);
   }
   // パストラバーサル検出（セキュリティ）
-  if (normalized.split(/[/\\]/).includes("..")) {
+  // @see Issue #215: 共通ユーティリティに統合
+  if (isPathTraversal(normalized)) {
     throw new Error(`Path traversal detected: ${filePath}`);
   }
   return normalized;

--- a/src/shared/fs/pathTraversal.ts
+++ b/src/shared/fs/pathTraversal.ts
@@ -1,0 +1,36 @@
+/**
+ * Path Traversal Detection Utility
+ *
+ * Unified path traversal detection logic extracted from:
+ * - normalizePathForDenylist (src/indexer/cli.ts)
+ * - resolveSafePath (src/shared/fs/safePath.ts)
+ *
+ * Uses segment-based detection (not substring) to avoid false positives
+ * on patterns like Next.js catch-all routes [...all].
+ *
+ * @see Issue #215: パストラバーサル検出ロジックの統合
+ * @see PR #214: improve path traversal detection accuracy
+ */
+
+/**
+ * Check if a path contains path traversal attempts
+ *
+ * Uses segment-based detection to avoid false positives on patterns like:
+ * - Next.js catch-all routes: [...all], [[...slug]]
+ * - File names containing ".." : bar..baz.ts
+ * - Directory names with partial "..": [..bar]
+ *
+ * @param path - The path to check (supports both Unix and Windows separators)
+ * @returns true if path traversal is detected
+ *
+ * @example
+ * isPathTraversal("../etc/passwd")     // true
+ * isPathTraversal("foo/../bar")        // true
+ * isPathTraversal("[...all]/route.ts") // false (Next.js pattern)
+ * isPathTraversal("foo/bar..baz.ts")   // false (filename with ..)
+ */
+export function isPathTraversal(path: string): boolean {
+  // Split on both forward slash and backslash (Windows support)
+  const segments = path.split(/[/\\]/);
+  return segments.includes("..");
+}

--- a/src/shared/fs/safePath.ts
+++ b/src/shared/fs/safePath.ts
@@ -1,6 +1,8 @@
 import { resolve, relative, sep } from "node:path";
 import process from "node:process";
 
+import { isPathTraversal } from "./pathTraversal.js";
+
 interface SafePathOptions {
   baseDir?: string;
   allowOutsideBase?: boolean;
@@ -26,7 +28,8 @@ export function resolveSafePath(inputPath: string, options?: SafePathOptions): s
     return resolved;
   }
 
-  if (relativePath.startsWith(`..${sep}`) || relativePath === "..") {
+  // @see Issue #215: 共通ユーティリティに統合
+  if (isPathTraversal(relativePath)) {
     throw new Error(`Path traversal attempt detected: ${inputPath}`);
   }
 

--- a/src/shared/fs/safePath.ts
+++ b/src/shared/fs/safePath.ts
@@ -1,4 +1,4 @@
-import { resolve, relative, sep } from "node:path";
+import { resolve, relative } from "node:path";
 import process from "node:process";
 
 import { isPathTraversal } from "./pathTraversal.js";

--- a/tests/shared/fs/pathTraversal.spec.ts
+++ b/tests/shared/fs/pathTraversal.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { isPathTraversal } from "../../../src/shared/fs/pathTraversal.js";
+
+describe("isPathTraversal", () => {
+  describe("パストラバーサル検出", () => {
+    it("先頭の .. を検出する", () => {
+      expect(isPathTraversal("../etc/passwd")).toBe(true);
+    });
+
+    it("中間の .. を検出する", () => {
+      expect(isPathTraversal("foo/../bar.ts")).toBe(true);
+    });
+
+    it("末尾の .. を検出する", () => {
+      expect(isPathTraversal("foo/bar/..")).toBe(true);
+    });
+
+    it("複数の .. を検出する", () => {
+      expect(isPathTraversal("../../secret")).toBe(true);
+    });
+
+    it("Windows形式の .. を検出する", () => {
+      expect(isPathTraversal("foo\\..\\bar")).toBe(true);
+    });
+
+    it("単独の .. を検出する", () => {
+      expect(isPathTraversal("..")).toBe(true);
+    });
+  });
+
+  describe("誤検知回避（PR #214 修正対象）", () => {
+    it("Next.js catch-all ルート [...all] を許可する", () => {
+      expect(isPathTraversal("api/auth/[...all]/route.ts")).toBe(false);
+    });
+
+    it("ファイル名内の .. を許可する", () => {
+      expect(isPathTraversal("foo/bar..baz.ts")).toBe(false);
+    });
+
+    it("ディレクトリ名内の .. を許可する（部分マッチ）", () => {
+      expect(isPathTraversal("foo/[..bar]/baz.ts")).toBe(false);
+    });
+
+    it("三点 ... を許可する", () => {
+      expect(isPathTraversal("foo/.../bar.ts")).toBe(false);
+    });
+
+    it("末尾三点のファイル名を許可する", () => {
+      expect(isPathTraversal("foo/bar.../baz.ts")).toBe(false);
+    });
+
+    it("Next.js optional catch-all [[...slug]] を許可する", () => {
+      expect(isPathTraversal("[[...slug]]/page.ts")).toBe(false);
+    });
+  });
+
+  describe("正常パス", () => {
+    it("通常のパスは false を返す", () => {
+      expect(isPathTraversal("foo/bar.ts")).toBe(false);
+    });
+
+    it("単一のドット . を許可する", () => {
+      expect(isPathTraversal(".")).toBe(false);
+    });
+
+    it("三点のみ ... を許可する", () => {
+      expect(isPathTraversal("...")).toBe(false);
+    });
+
+    it("空文字を許可する", () => {
+      expect(isPathTraversal("")).toBe(false);
+    });
+
+    it("深いネストのパスを許可する", () => {
+      expect(isPathTraversal("a/b/c/d/e/f/g.ts")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create shared `isPathTraversal()` utility in `src/shared/fs/pathTraversal.ts`
- Update `normalizePathForDenylist()` to use shared utility
- Update `resolveSafePath()` to use shared utility
- Add 17 comprehensive tests for `isPathTraversal()`

## Motivation
Issue #215 で指摘された通り、パストラバーサル検出ロジックが2箇所に分散していた:
- `normalizePathForDenylist` (src/indexer/cli.ts)
- `resolveSafePath` (src/shared/fs/safePath.ts)

## Implementation
PR #214 で導入されたセグメントベースの検出ロジック（`split(/[/\\]/).includes("..")`）を共通ユーティリティとして抽出。

```typescript
export function isPathTraversal(path: string): boolean {
  const segments = path.split(/[/\\]/);
  return segments.includes("..");
}
```

## Test plan
- [x] `tests/shared/fs/pathTraversal.spec.ts` - 17 tests
- [x] `tests/indexer/normalize-path-for-denylist.spec.ts` - 24 tests (既存、変更後も全て通過)
- [x] Full test suite: 994 tests passed

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)